### PR TITLE
BROOKLYN-1408 - DataHub - snprintf writing to insufficient buffer size

### DIFF
--- a/components/dataHub/dataSample.c
+++ b/components/dataHub/dataSample.c
@@ -159,8 +159,8 @@ static size_t EscapeCharacter
         default:
         {
             /* Unicode codepoint */
-            int len = snprintf(&escapedChar[1], 4,"u%04x", inputChar[0]);
-            LE_ASSERT(len == 4);
+            int len = snprintf(&escapedChar[1], 6,"u%04x", inputChar[0]);
+            LE_ASSERT(len == 5);
             break;
         }
     }


### PR DESCRIPTION
Size error in EscapeCharacter:
/ws/mangOH/mangOH/apps/DataHub/components/dataHub/dataSample.c:162:53: error: '%04x' directive output truncated writing 4 bytes into a region of size 3 [-Werror=format-truncation=]
             int len = snprintf(&escapedChar[1], 4,"u%04x", inputChar[0]);
                                                     ^~~~
/ws/mangOH/mangOH/apps/DataHub/components/dataHub/dataSample.c:162:17: note: 'snprintf' output 6 bytes into a destination of size 4
             int len = snprintf(&escapedChar[1], 4,"u%04x", inputChar[0]);
                 ^~~
Destination should be 6 bytes and length check should be 5.