### PR TITLE
BROOKLYN-1779 Fixed Data Hub is out of memory

### DIFF
--- a/dataHub.adef
+++ b/dataHub.adef
@@ -33,6 +33,8 @@ processes:
     faultAction: restart
 }
 
+maxMemoryBytes: 81920K
+
 extern:
 {
     hubd.dataHub.le_appInfo


### PR DESCRIPTION
Hi,
This bug is seen on Chamberlain setup, when two consecutive BPs are applied.
Data Hub crashes has it is out of memory.
Legato apps have by default 40MB of RAM allocated.
By moving this limit to 80MB for Data Hub, when applying consecutively the 3 Blueprints there is no more crash. More details about memory usage in https://issues.sierrawireless.com/browse/BROOKLYN-1779.
Thanks
Nico