### PR TITLE
BROOKLYN-2219 Avoid to kill client when adding a push handler is failing

### DIFF
--- a/components/dataHub/adminService.c
+++ b/components/dataHub/adminService.c
@@ -254,7 +254,7 @@ static hub_HandlerRef_t AddPushHandler
     resTree_EntryRef_t resRef = resTree_GetResource(resTree_GetRoot(), path);
     if (resRef == NULL)
     {
-        LE_KILL_CLIENT("Bad resource path '%s'.", path);
+        LE_CRIT("Bad resource path '%s'.", path);
         return NULL;
     }
 

--- a/components/dataHub/ioService.c
+++ b/components/dataHub/ioService.c
@@ -490,7 +490,7 @@ static hub_HandlerRef_t AddPushHandler
     resTree_EntryRef_t nsRef = hub_GetClientNamespace(io_GetClientSessionRef());
     if (nsRef == NULL)
     {
-        LE_KILL_CLIENT("Client tried to register a push handler before creating any resources.");
+        LE_CRIT("Client tried to register a push handler before creating any resources.");
         return NULL;
     }
 
@@ -498,18 +498,18 @@ static hub_HandlerRef_t AddPushHandler
 
     if (resRef == NULL)
     {
-        LE_KILL_CLIENT("Attempt to register Push handler on non-existent resource '/app/%s/%s'.",
-                       resTree_GetEntryName(nsRef),
-                       path);
+        LE_CRIT("Attempt to register Push handler on non-existent resource '/app/%s/%s'.",
+                resTree_GetEntryName(nsRef),
+                path);
         return NULL;
     }
 
     admin_EntryType_t entryType = resTree_GetEntryType(resRef);
     if ((entryType != ADMIN_ENTRY_TYPE_INPUT) && (entryType != ADMIN_ENTRY_TYPE_OUTPUT))
     {
-        LE_KILL_CLIENT("Attempt to register Push handler before creating resource '/app/%s/%s'.",
-                       resTree_GetEntryName(nsRef),
-                       path);
+        LE_CRIT("Attempt to register Push handler before creating resource '/app/%s/%s'.",
+                resTree_GetEntryName(nsRef),
+                path);
         return NULL;
     }
 

--- a/components/dataHub/queryService.c
+++ b/components/dataHub/queryService.c
@@ -1021,7 +1021,7 @@ static hub_HandlerRef_t AddPushHandler
     resTree_EntryRef_t resRef = resTree_GetResource(resTree_GetRoot(), path);
     if (resRef == NULL)
     {
-        LE_KILL_CLIENT("Bad resource path '%s'.", path);
+        LE_CRIT("Bad resource path '%s'.", path);
         return NULL;
     }
 


### PR DESCRIPTION
Hi,
The goal of this ticket is to make once again the Data Hub more kind when an error happens when adding a push handler.
The changes remove the kill of the client. The returned NULL value can then be used by the client to take the most appropriate decision (ie : raise an error, try to create the missing resource, try to create the handler later, etc.).
The changes were motivated by BROOKLYN-2219. Please refer to it for the details.
Nicolas