### PR TITLE
Fixed trigger conversion in JSON

### DIFF
--- a/components/dataHub/dataSample.c
+++ b/components/dataHub/dataSample.c
@@ -769,13 +769,8 @@ const le_result_t dataSample_ConvertToJson
     switch (dataType)
     {
         case IO_DATA_TYPE_TRIGGER:
-
-            if (valueBuffSize > 4)
-            {
-                snprintf(valueBuffPtr, valueBuffSize, "null");
-                return LE_OK;
-            }
-            return LE_OVERFLOW;
+        
+            return le_utf8_Copy(valueBuffPtr, "null", valueBuffSize, NULL);
 
         case IO_DATA_TYPE_BOOLEAN:
         {


### PR DESCRIPTION
https://issues.sierrawireless.com/browse/BROOKLYN-3060

Currently a trigger is translated into an empty string. See `dataSample_ConvertToJson` in apps/DataHub/components/dataHub/dataSample.c
This is not a valid JSON.
The proposal is to convert triggers as numeric value "1".