### PR TITLE
BROOKLYN-3444 - Update comment in dataHub API  to add LE_FAULT for CreateInput and CreateOutput

### DIFF
--- a/components/dataHub/ioService.c
+++ b/components/dataHub/ioService.c
@@ -86,6 +86,7 @@ static resTree_EntryRef_t FindResource
  *  - LE_OK if successful.
  *  - LE_DUPLICATE if a resource by that name exists but with different direction, type or units.
  *  - LE_NO_MEMORY if the client is not permitted to create that many resources.
+ *  - LE_FAULT if there was an error.
  */
 //--------------------------------------------------------------------------------------------------
 le_result_t io_CreateInput
@@ -149,7 +150,7 @@ le_result_t io_CreateInput
     if (resRef == NULL)
     {
         LE_ERROR("Failed to create Input '/app/%s/%s'.", resTree_GetEntryName(nsRef), path);
-        return LE_FAULT;    // Client has been killed, so it doesn't matter what we return.
+        return LE_FAULT;
     }
 
     return LE_OK;
@@ -207,6 +208,7 @@ void io_SetJsonExample
  *  - LE_OK if successful.
  *  - LE_DUPLICATE if a resource by that name exists but with different direction, type or units.
  *  - LE_NO_MEMORY if the client is not permitted to create that many resources.
+ *  - LE_FAULT if there was an error.
  */
 //--------------------------------------------------------------------------------------------------
 le_result_t io_CreateOutput
@@ -270,7 +272,7 @@ le_result_t io_CreateOutput
     if (resRef == NULL)
     {
         LE_ERROR("Failed to create Output '/app/%s/%s'.", resTree_GetEntryName(nsRef), path);
-        return LE_FAULT;    // Client has been killed, so it doesn't matter what we return.
+        return LE_FAULT; 
     }
 
     return LE_OK;

--- a/io.api
+++ b/io.api
@@ -390,6 +390,7 @@ ENUM DataType
  *  - LE_OK if successful.
  *  - LE_DUPLICATE if a resource by that name exists but with different direction, type or units.
  *  - LE_NO_MEMORY if the client is not permitted to create that many resources.
+ *  - LE_FAULT if there was an error.
  */
 //--------------------------------------------------------------------------------------------------
 FUNCTION le_result_t CreateInput
@@ -424,6 +425,7 @@ FUNCTION SetJsonExample
  *  - LE_OK if successful.
  *  - LE_DUPLICATE if a resource by that name exists but with different direction, type or units.
  *  - LE_NO_MEMORY if the client is not permitted to create that many resources.
+ *  - LE_FAULT if there was an error.
  */
 //--------------------------------------------------------------------------------------------------
 FUNCTION le_result_t CreateOutput


### PR DESCRIPTION
BROOKLYN-3444(https://issues.sierrawireless.com/browse/BROOKLYN-3444)

According to remarks  https://github.com/flowthings/datahub/commit/483ec75eea8a17d41608c365fd20a88919f6f73f
1. remove the unused comment in ioService.c
2.  update description  of CreateInput and CreateOuput function