### PR TITLE
BROOKLYN-3522  DataHub error when setting an observation on nested resource

### DIFF
--- a/components/json/json.c
+++ b/components/json/json.c
@@ -511,7 +511,8 @@ static const char* GetMemberName
 {
     size_t i = 0;
 
-    while ((i < buffSize) && isalnum(*specPtr))
+    while ((i < buffSize) && 
+           (isalnum(*specPtr) || (*specPtr == '_') || (*specPtr == '-')))
     {
         *buffPtr = *specPtr;
 


### PR DESCRIPTION
**Issue:**

Since BROOKLYN-1464 setting an observation on a nested resource is in theory supported. However an obs on /util/cellular/signal/value.rx_level does not work:

```
Dec 18 11:03:45 fx30s user.warn Legato: -WRN- | dataHub[1041]/dataHub T=main | dataSample.c dataSample_ExtractJson() 867 | Failed to extract 'rx_level' from JSON '{"rat":"lte","status":"registered","bars":3,"rx_level":-36,"gsm":{"ber":null},"lte":{"rsrp":-76,"rsrq":-
```
 
**Solution:**

Add '_' and '-'  as allowed character for the name of a resource in GetMemberName():json.c
