### PR TITLE
BROOKLYN-3546 - Merge snapshot API from legato datahub

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ _build_*
 *.update
 docs
 backup
+.gdb_history

--- a/Makefile
+++ b/Makefile
@@ -1,20 +1,28 @@
 
 TARGET ?= localhost
 
-.PHONY: all dataHub appInfoStub sensor actuator
-all: dataHub appInfoStub sensor actuator
+DBG :=
+ifeq ($(D),1)
+    DBG := -d $(LEGATO_ROOT)/build/$(TARGET)/debug
+endif
+
+.PHONY: all dataHub appInfoStub sensor actuator snapshot
+all: dataHub appInfoStub sensor actuator snapshot
 
 dataHub:
-	mkapp -t $(TARGET) dataHub.adef -i $(LEGATO_ROOT)/interfaces/supervisor
+	mkapp -t $(TARGET) dataHub.adef -i $(LEGATO_ROOT)/interfaces/supervisor $(DBG)
 
 appInfoStub:
-	mkapp -t $(TARGET) test/appInfoStub.adef -i $(LEGATO_ROOT)/interfaces/supervisor -i $(CURDIR)
+	mkapp -t $(TARGET) test/appInfoStub.adef -i $(LEGATO_ROOT)/interfaces/supervisor -i $(CURDIR) $(DBG)
 
 sensor:
-	mkapp -t $(TARGET) test/sensor.adef -i $(PWD) -s components -i components/periodicSensor
+	mkapp -t $(TARGET) test/sensor.adef -i $(PWD) -s components -i components/periodicSensor $(DBG)
 
 actuator:
-	mkapp -t $(TARGET) test/actuator.adef -i $(PWD)
+	mkapp -t $(TARGET) test/actuator.adef -i $(PWD) $(DBG)
+
+snapshot:
+	mkapp -t $(TARGET) test/snapshot.adef -i $(PWD) $(DBG)
 
 .PHONY: clean
 clean:
@@ -33,6 +41,7 @@ start: stop all
 	sdir bind "<$(USER)>.dhubToolAdmin" "<$(USER)>.admin"
 	sdir bind "<$(USER)>.dhubToolIo" "<$(USER)>.io"
 	sdir bind "<$(USER)>.dhubToolQuery" "<$(USER)>.query"
+	sdir bind "<$(USER)>.dsnap.snapshot.query" "<$(USER)>.query"
 	test/supervisor
 	$(DHUB) set backupPeriod temp 5
 	$(DHUB) set bufferSize temp 100

--- a/Makefile
+++ b/Makefile
@@ -38,6 +38,7 @@ start: stop all
 	sdir bind "<$(USER)>.sensord.sensor.io" "<$(USER)>.io"
 	sdir bind "<$(USER)>.sensord.periodicSensor.dhubIO" "<$(USER)>.io"
 	sdir bind "<$(USER)>.actuatord.actuator.io" "<$(USER)>.io"
+	sdir bind "<$(USER)>.actuatord.actuator.admin" "<$(USER)>.admin"
 	sdir bind "<$(USER)>.dhubToolAdmin" "<$(USER)>.admin"
 	sdir bind "<$(USER)>.dhubToolIo" "<$(USER)>.io"
 	sdir bind "<$(USER)>.dhubToolQuery" "<$(USER)>.query"

--- a/Makefile
+++ b/Makefile
@@ -6,11 +6,16 @@ ifeq ($(D),1)
     DBG := -d $(LEGATO_ROOT)/build/$(TARGET)/debug
 endif
 
+OCTAVE :=
+#ifeq ($(O),1)
+    OCTAVE := -C -DWITH_OCTAVE -C -Icomponents/octaveFormatter
+#endif
+
 .PHONY: all dataHub appInfoStub sensor actuator snapshot
 all: dataHub appInfoStub sensor actuator snapshot
 
 dataHub:
-	mkapp -t $(TARGET) dataHub.adef -i $(LEGATO_ROOT)/interfaces/supervisor $(DBG)
+	mkapp -t $(TARGET) dataHub.adef -i $(LEGATO_ROOT)/interfaces/supervisor $(DBG) ${OCTAVE}
 
 appInfoStub:
 	mkapp -t $(TARGET) test/appInfoStub.adef -i $(LEGATO_ROOT)/interfaces/supervisor -i $(CURDIR) $(DBG)
@@ -22,7 +27,7 @@ actuator:
 	mkapp -t $(TARGET) test/actuator.adef -i $(PWD) $(DBG)
 
 snapshot:
-	mkapp -t $(TARGET) test/snapshot.adef -i $(PWD) $(DBG)
+	mkapp -t $(TARGET) test/snapshot.adef -i $(PWD) $(DBG) ${OCTAVE}
 
 .PHONY: clean
 clean:

--- a/components/dataHub/Component.cdef
+++ b/components/dataHub/Component.cdef
@@ -30,16 +30,17 @@ requires:
 
 sources:
 {
+    adminService.c
     dataHub.c
     dataSample.c
-    resTree.c
+    handler.c
+    ioPoint.c
     ioService.c
-    adminService.c
+    obs.c
     queryService.c
     resource.c
-    ioPoint.c
-    obs.c
-    handler.c
+    resTree.c
+    snapshot.c
 }
 
 cflags:

--- a/components/dataHub/Component.cdef
+++ b/components/dataHub/Component.cdef
@@ -25,6 +25,7 @@ requires:
     component:
     {
         $CURDIR/../json
+        $CURDIR/../jsonFormatter
     }
 }
 
@@ -46,4 +47,5 @@ sources:
 cflags:
 {
     -I$CURDIR/../json
+    -I$CURDIR/../jsonFormatter
 }

--- a/components/dataHub/Component.cdef
+++ b/components/dataHub/Component.cdef
@@ -26,6 +26,9 @@ requires:
     {
         $CURDIR/../json
         $CURDIR/../jsonFormatter
+#if ${MK_CONFIG_ENABLE_OCTAVE} = y
+        $CURDIR/../octaveFormatter
+#endif
     }
 }
 
@@ -48,4 +51,8 @@ cflags:
 {
     -I$CURDIR/../json
     -I$CURDIR/../jsonFormatter
+#if ${MK_CONFIG_ENABLE_OCTAVE} = y
+    -I$CURDIR/../octaveFormatter
+    -DWITH_OCTAVE
+#endif
 }

--- a/components/dataHub/dataHub.c
+++ b/components/dataHub/dataHub.c
@@ -31,6 +31,7 @@
 #include "obs.h"
 #include "ioService.h"
 #include "adminService.h"
+#include "snapshot.h"
 
 
 //--------------------------------------------------------------------------------------------------
@@ -48,6 +49,7 @@ COMPONENT_INIT
     resTree_Init();
     ioService_Init();
     adminService_Init();
+    snapshot_Init();
 
     LE_INFO("Data Hub started.");
 }

--- a/components/dataHub/dataSample.h
+++ b/components/dataHub/dataSample.h
@@ -147,7 +147,7 @@ LE_SHARED double dataSample_GetTimestamp
  * @warning You had better be sure that this is a Boolean Data Sample.
  */
 //--------------------------------------------------------------------------------------------------
-bool dataSample_GetBoolean
+LE_SHARED bool dataSample_GetBoolean
 (
     dataSample_Ref_t sampleRef
 );
@@ -162,7 +162,7 @@ bool dataSample_GetBoolean
  * @warning You had better be sure that this is a Numeric Data Sample.
  */
 //--------------------------------------------------------------------------------------------------
-double dataSample_GetNumeric
+LE_SHARED double dataSample_GetNumeric
 (
     dataSample_Ref_t sampleRef
 );
@@ -177,7 +177,7 @@ double dataSample_GetNumeric
  * @warning You had better be sure that this is a String Data Sample.
  */
 //--------------------------------------------------------------------------------------------------
-const char* dataSample_GetString
+LE_SHARED const char* dataSample_GetString
 (
     dataSample_Ref_t sampleRef
 );
@@ -192,7 +192,7 @@ const char* dataSample_GetString
  * @warning You had better be sure that this is a JSON Data Sample.
  */
 //--------------------------------------------------------------------------------------------------
-const char* dataSample_GetJson
+LE_SHARED const char* dataSample_GetJson
 (
     dataSample_Ref_t sampleRef
 );

--- a/components/dataHub/dataSample.h
+++ b/components/dataHub/dataSample.h
@@ -132,7 +132,7 @@ dataSample_Ref_t dataSample_CreateJson
  * @return The timestamp, in seconds since the Epoch (1970/01/01 00:00:00 UTC).
  */
 //--------------------------------------------------------------------------------------------------
-double dataSample_GetTimestamp
+LE_SHARED double dataSample_GetTimestamp
 (
     dataSample_Ref_t sampleRef
 );
@@ -225,7 +225,7 @@ const le_result_t dataSample_ConvertToString
  *  - LE_OVERFLOW if the buffer provided is too small to hold the value.
  */
 //--------------------------------------------------------------------------------------------------
-const le_result_t dataSample_ConvertToJson
+LE_SHARED le_result_t dataSample_ConvertToJson
 (
     dataSample_Ref_t sampleRef,
     io_DataType_t dataType, ///< [IN] The data type of the data sample.

--- a/components/dataHub/resTree.c
+++ b/components/dataHub/resTree.c
@@ -28,7 +28,12 @@ typedef struct resTree_Entry
     char name[HUB_MAX_ENTRY_NAME_BYTES]; ///< Name of the entry.
     le_dls_List_t childList;  ///< List of child entries.
     admin_EntryType_t type; ///< The type of entry.
-    res_Resource_t* resourcePtr;    ///< Ptr to the Resource object or NULL if just a Namespace.
+
+    union
+    {
+        res_Resource_t  *resourcePtr;   ///< Ptr to the Resource object.
+        uint32_t         flags;         ///< Flags if this is just a namespace.
+    } u;
 }
 Entry_t;
 
@@ -67,7 +72,7 @@ static Entry_t* AddChild
 
     entryPtr->childList = LE_DLS_LIST_INIT;
     entryPtr->type = ADMIN_ENTRY_TYPE_NAMESPACE;
-    entryPtr->resourcePtr = NULL;
+    entryPtr->u.flags = 0;
 
     if (parentPtr != NULL)
     {
@@ -100,7 +105,7 @@ static void EntryDestructor
 
     LE_ASSERT(entryPtr->parentPtr != NULL);
     LE_ASSERT(le_dls_IsEmpty(&entryPtr->childList));
-    LE_ASSERT(entryPtr->resourcePtr == NULL);
+    LE_ASSERT(entryPtr->u.flags == 0);
 
     // Remove from parent's list of children.
     le_dls_Remove(&entryPtr->parentPtr->childList, &entryPtr->link);
@@ -145,7 +150,14 @@ bool resTree_IsResource
 )
 //--------------------------------------------------------------------------------------------------
 {
-    return (entryRef->resourcePtr != NULL);
+    if (entryRef->type == ADMIN_ENTRY_TYPE_NAMESPACE)
+    {
+        return false;
+    }
+    else
+    {
+        return (entryRef->u.resourcePtr != NULL);
+    }
 }
 
 
@@ -305,18 +317,21 @@ static void ReplaceResource
 //--------------------------------------------------------------------------------------------------
 {
     // If we're replacing an existing Resource with another type, move Resource settings over.
-    if (entryRef->resourcePtr != NULL)
+    if (entryRef->type != ADMIN_ENTRY_TYPE_NAMESPACE)
     {
-        // Note that this may result in lost settings. For example, Placeholders don't have
-        // filter settings, but Observations do, so moving settings from an Observation to a
-        // Placeholder will lose the Observation's filter settings.
-        res_MoveAdminSettings(entryRef->resourcePtr, replacementPtr, replacementType);
+        if (entryRef->u.resourcePtr != NULL)
+        {
+            // Note that this may result in lost settings. For example, Placeholders don't have
+            // filter settings, but Observations do, so moving settings from an Observation to a
+            // Placeholder will lose the Observation's filter settings.
+            res_MoveAdminSettings(entryRef->u.resourcePtr, replacementPtr, replacementType);
 
-        // Delete the original resource.
-        le_mem_Release(entryRef->resourcePtr);
+            // Delete the original resource.
+            le_mem_Release(entryRef->u.resourcePtr);
+        }
     }
 
-    entryRef->resourcePtr = replacementPtr;
+    entryRef->u.resourcePtr = replacementPtr;
     entryRef->type = replacementType;
 }
 
@@ -431,7 +446,7 @@ const char* resTree_GetUnits
 {
     LE_ASSERT(resTree_IsResource(resRef));
 
-    return res_GetUnits(resRef->resourcePtr);
+    return res_GetUnits(resRef->u.resourcePtr);
 }
 
 
@@ -453,7 +468,7 @@ io_DataType_t resTree_GetDataType
 {
     LE_ASSERT(resTree_IsResource(resRef));
 
-    return res_GetDataType(resRef->resourcePtr);
+    return res_GetDataType(resRef->u.resourcePtr);
 }
 
 
@@ -897,7 +912,7 @@ void resTree_Push
         case ADMIN_ENTRY_TYPE_OBSERVATION:
         case ADMIN_ENTRY_TYPE_PLACEHOLDER:
 
-            res_Push(entryRef->resourcePtr, dataType, NULL, dataSample);
+            res_Push(entryRef->u.resourcePtr, dataType, NULL, dataSample);
             break;
 
         case ADMIN_ENTRY_TYPE_NAMESPACE:
@@ -930,7 +945,7 @@ hub_HandlerRef_t resTree_AddPushHandler
 )
 //--------------------------------------------------------------------------------------------------
 {
-    return res_AddPushHandler(resRef->resourcePtr,
+    return res_AddPushHandler(resRef->u.resourcePtr,
                               dataType,
                               callbackPtr,
                               contextPtr);
@@ -955,7 +970,7 @@ dataSample_Ref_t resTree_GetCurrentValue
         return NULL;
     }
 
-    return res_GetCurrentValue(resRef->resourcePtr);
+    return res_GetCurrentValue(resRef->u.resourcePtr);
 }
 
 
@@ -980,7 +995,8 @@ le_result_t resTree_SetSource
     LE_ASSERT(destEntry->type != ADMIN_ENTRY_TYPE_NAMESPACE);
     LE_ASSERT(destEntry->type != ADMIN_ENTRY_TYPE_NONE);
 
-    return res_SetSource(destEntry->resourcePtr, (srcEntry != NULL ? srcEntry->resourcePtr : NULL));
+    return res_SetSource(destEntry->u.resourcePtr,
+        (srcEntry != NULL ? srcEntry->u.resourcePtr : NULL));
 }
 
 
@@ -1000,7 +1016,7 @@ resTree_EntryRef_t resTree_GetSource
 {
     if (resTree_IsResource(destEntry))
     {
-        return res_GetSource(destEntry->resourcePtr);
+        return res_GetSource(destEntry->u.resourcePtr);
     }
 
     return NULL;
@@ -1020,7 +1036,7 @@ void resTree_DeleteIO
 )
 //--------------------------------------------------------------------------------------------------
 {
-    res_Resource_t* ioPtr = entryRef->resourcePtr;
+    res_Resource_t* ioPtr = entryRef->u.resourcePtr;
 
     // Call handlers before we release the Resource memory, or re-assign it to
     // become a placeholder. Replacing with a placeholder is still considered a "remove"
@@ -1038,7 +1054,7 @@ void resTree_DeleteIO
     else
     {
         // Detach the IO resource from the resource tree entry (converting it into a namespace).
-        entryRef->resourcePtr = NULL;
+        entryRef->u.flags = 0;
         entryRef->type = ADMIN_ENTRY_TYPE_NAMESPACE;
 
         // Release the IO resource.
@@ -1065,10 +1081,10 @@ void resTree_DeleteObservation
     CallResourceTreeChangeHandlers(obsEntry, ADMIN_ENTRY_TYPE_OBSERVATION, ADMIN_RESOURCE_REMOVED);
 
     // Delete the Observation resource object.
-    res_DeleteObservation(obsEntry->resourcePtr);
+    res_DeleteObservation(obsEntry->u.resourcePtr);
 
     // Convert the resource tree entry into a namespace, detaching the Observation resource from it.
-    obsEntry->resourcePtr = NULL;
+    obsEntry->u.flags = 0;
     obsEntry->type = ADMIN_ENTRY_TYPE_NAMESPACE;
 
     // Release the namespace (resource tree entry).  This will cause it to be removed from the
@@ -1091,7 +1107,7 @@ void resTree_SetMinPeriod
 )
 //--------------------------------------------------------------------------------------------------
 {
-    res_SetMinPeriod(obsEntry->resourcePtr, minPeriod);
+    res_SetMinPeriod(obsEntry->u.resourcePtr, minPeriod);
 }
 
 
@@ -1108,7 +1124,7 @@ double resTree_GetMinPeriod
 )
 //--------------------------------------------------------------------------------------------------
 {
-    return res_GetMinPeriod(obsEntry->resourcePtr);
+    return res_GetMinPeriod(obsEntry->u.resourcePtr);
 }
 
 
@@ -1126,7 +1142,7 @@ void resTree_SetHighLimit
 )
 //--------------------------------------------------------------------------------------------------
 {
-    res_SetHighLimit(obsEntry->resourcePtr, highLimit);
+    res_SetHighLimit(obsEntry->u.resourcePtr, highLimit);
 }
 
 
@@ -1143,7 +1159,7 @@ double resTree_GetHighLimit
 )
 //--------------------------------------------------------------------------------------------------
 {
-    return res_GetHighLimit(obsEntry->resourcePtr);
+    return res_GetHighLimit(obsEntry->u.resourcePtr);
 }
 
 
@@ -1161,7 +1177,7 @@ void resTree_SetLowLimit
 )
 //--------------------------------------------------------------------------------------------------
 {
-    res_SetLowLimit(obsEntry->resourcePtr, lowLimit);
+    res_SetLowLimit(obsEntry->u.resourcePtr, lowLimit);
 }
 
 
@@ -1178,7 +1194,7 @@ double resTree_GetLowLimit
 )
 //--------------------------------------------------------------------------------------------------
 {
-    return res_GetLowLimit(obsEntry->resourcePtr);
+    return res_GetLowLimit(obsEntry->u.resourcePtr);
 }
 
 
@@ -1199,7 +1215,7 @@ void resTree_SetChangeBy
 )
 //--------------------------------------------------------------------------------------------------
 {
-    res_SetChangeBy(obsEntry->resourcePtr, change);
+    res_SetChangeBy(obsEntry->u.resourcePtr, change);
 }
 
 
@@ -1217,7 +1233,7 @@ double resTree_GetChangeBy
 )
 //--------------------------------------------------------------------------------------------------
 {
-    return res_GetChangeBy(obsEntry->resourcePtr);
+    return res_GetChangeBy(obsEntry->u.resourcePtr);
 }
 
 
@@ -1238,7 +1254,7 @@ void resTree_SetTransform
 )
 //--------------------------------------------------------------------------------------------------
 {
-    res_SetTransform(obsEntry->resourcePtr, transformType, paramsPtr, paramsSize);
+    res_SetTransform(obsEntry->u.resourcePtr, transformType, paramsPtr, paramsSize);
 }
 
 
@@ -1255,7 +1271,7 @@ admin_TransformType_t resTree_GetTransform
 )
 //--------------------------------------------------------------------------------------------------
 {
-    return res_GetTransform(obsEntry->resourcePtr);
+    return res_GetTransform(obsEntry->u.resourcePtr);
 }
 
 
@@ -1272,7 +1288,7 @@ void resTree_SetBufferMaxCount
 )
 //--------------------------------------------------------------------------------------------------
 {
-    res_SetBufferMaxCount(obsEntry->resourcePtr, count);
+    res_SetBufferMaxCount(obsEntry->u.resourcePtr, count);
 }
 
 
@@ -1289,7 +1305,7 @@ uint32_t resTree_GetBufferMaxCount
 )
 //--------------------------------------------------------------------------------------------------
 {
-    return res_GetBufferMaxCount(obsEntry->resourcePtr);
+    return res_GetBufferMaxCount(obsEntry->u.resourcePtr);
 }
 
 
@@ -1308,7 +1324,7 @@ void resTree_SetBufferBackupPeriod
 )
 //--------------------------------------------------------------------------------------------------
 {
-    res_SetBufferBackupPeriod(obsEntry->resourcePtr, seconds);
+    res_SetBufferBackupPeriod(obsEntry->u.resourcePtr, seconds);
 }
 
 
@@ -1327,7 +1343,7 @@ uint32_t resTree_GetBufferBackupPeriod
 )
 //--------------------------------------------------------------------------------------------------
 {
-    return res_GetBufferBackupPeriod(obsEntry->resourcePtr);
+    return res_GetBufferBackupPeriod(obsEntry->u.resourcePtr);
 }
 
 
@@ -1342,7 +1358,7 @@ void resTree_MarkOptional
 )
 //--------------------------------------------------------------------------------------------------
 {
-    res_MarkOptional(resEntry->resourcePtr);
+    res_MarkOptional(resEntry->u.resourcePtr);
 }
 
 
@@ -1366,7 +1382,7 @@ bool resTree_IsMandatory
     }
     else
     {
-        return res_IsMandatory(resEntry->resourcePtr);
+        return res_IsMandatory(resEntry->u.resourcePtr);
     }
 }
 
@@ -1387,7 +1403,7 @@ void resTree_SetDefault
 )
 //--------------------------------------------------------------------------------------------------
 {
-    res_SetDefault(resEntry->resourcePtr, dataType, value);
+    res_SetDefault(resEntry->u.resourcePtr, dataType, value);
 }
 
 
@@ -1404,7 +1420,7 @@ bool resTree_HasDefault
 )
 //--------------------------------------------------------------------------------------------------
 {
-    return res_HasDefault(resEntry->resourcePtr);
+    return res_HasDefault(resEntry->u.resourcePtr);
 }
 
 
@@ -1421,7 +1437,7 @@ io_DataType_t resTree_GetDefaultDataType
 )
 //--------------------------------------------------------------------------------------------------
 {
-    return res_GetDefaultDataType(resEntry->resourcePtr);
+    return res_GetDefaultDataType(resEntry->u.resourcePtr);
 }
 
 
@@ -1438,7 +1454,7 @@ dataSample_Ref_t resTree_GetDefaultValue
 )
 //--------------------------------------------------------------------------------------------------
 {
-    return res_GetDefaultValue(resEntry->resourcePtr);
+    return res_GetDefaultValue(resEntry->u.resourcePtr);
 }
 
 
@@ -1453,7 +1469,7 @@ void resTree_RemoveDefault
 )
 //--------------------------------------------------------------------------------------------------
 {
-    return res_RemoveDefault(resEntry->resourcePtr);
+    return res_RemoveDefault(resEntry->u.resourcePtr);
 }
 
 
@@ -1473,7 +1489,7 @@ void resTree_SetOverride
 )
 //--------------------------------------------------------------------------------------------------
 {
-    res_SetOverride(resEntry->resourcePtr, dataType, value);
+    res_SetOverride(resEntry->u.resourcePtr, dataType, value);
 }
 
 
@@ -1490,7 +1506,7 @@ bool resTree_HasOverride
 )
 //--------------------------------------------------------------------------------------------------
 {
-    return res_HasOverride(resEntry->resourcePtr);
+    return res_HasOverride(resEntry->u.resourcePtr);
 }
 
 
@@ -1507,7 +1523,7 @@ io_DataType_t resTree_GetOverrideDataType
 )
 //--------------------------------------------------------------------------------------------------
 {
-    return res_GetOverrideDataType(resEntry->resourcePtr);
+    return res_GetOverrideDataType(resEntry->u.resourcePtr);
 }
 
 
@@ -1524,7 +1540,7 @@ dataSample_Ref_t resTree_GetOverrideValue
 )
 //--------------------------------------------------------------------------------------------------
 {
-    return res_GetOverrideValue(resEntry->resourcePtr);
+    return res_GetOverrideValue(resEntry->u.resourcePtr);
 }
 
 
@@ -1539,9 +1555,77 @@ void resTree_RemoveOverride
 )
 //--------------------------------------------------------------------------------------------------
 {
-    return res_RemoveOverride(resEntry->resourcePtr);
+    return res_RemoveOverride(resEntry->u.resourcePtr);
 }
 
+//--------------------------------------------------------------------------------------------------
+/**
+ * Get the last modified time stamp of a resource.
+ *
+ * @return Time stamp value, in seconds since the Epoch, or -1 if no time stamp value exists.
+ */
+//--------------------------------------------------------------------------------------------------
+double resTree_GetLastModified
+(
+    resTree_EntryRef_t resEntry ///< Resource to query.
+)
+{
+    dataSample_Ref_t value;
+
+    if (resEntry->type != ADMIN_ENTRY_TYPE_NAMESPACE)
+    {
+        value = resTree_GetCurrentValue(resEntry);
+        if (value != NULL)
+        {
+            return dataSample_GetTimestamp(value);
+        }
+    }
+
+    return -1;
+}
+
+//--------------------------------------------------------------------------------------------------
+/**
+ * Set the node's relevance flag.
+ */
+//--------------------------------------------------------------------------------------------------
+void resTree_SetRelevance
+(
+    resTree_EntryRef_t  resEntry,   ///< Resource to query.
+    bool                relevant    ///< Relevance of node to current operation.
+)
+{
+    if (resEntry->type == ADMIN_ENTRY_TYPE_NAMESPACE)
+    {
+        resEntry->u.flags |= RES_FLAG_RELEVANT;
+    }
+    else
+    {
+        res_SetRelevance(resEntry->u.resourcePtr, relevant);
+    }
+}
+
+//--------------------------------------------------------------------------------------------------
+/**
+ * Get the node's relevance flag.
+ *
+ * @return Relevance of node to the current operation.
+ */
+//--------------------------------------------------------------------------------------------------
+bool resTree_IsRelevant
+(
+    resTree_EntryRef_t resEntry ///< Resource to query.
+)
+{
+    if (resEntry->type == ADMIN_ENTRY_TYPE_NAMESPACE)
+    {
+        return (resEntry->u.flags & RES_FLAG_RELEVANT);
+    }
+    else
+    {
+        return res_IsRelevant(resEntry->u.resourcePtr);
+    }
+}
 
 //--------------------------------------------------------------------------------------------------
 /**
@@ -1597,9 +1681,9 @@ static void ForEachResourceUnder
     {
         Entry_t* childPtr = CONTAINER_OF(linkPtr, Entry_t, link);
 
-        if (childPtr->resourcePtr != NULL)
+        if (childPtr->type != ADMIN_ENTRY_TYPE_NAMESPACE && childPtr->u.resourcePtr != NULL)
         {
-            func(childPtr->resourcePtr, childPtr->type);
+            func(childPtr->u.resourcePtr, childPtr->type);
         }
 
         ForEachResourceUnder(childPtr, func);
@@ -1648,10 +1732,10 @@ void resTree_ReadBufferJson
 )
 //--------------------------------------------------------------------------------------------------
 {
-    LE_ASSERT(obsEntry->resourcePtr != NULL);
     LE_ASSERT(obsEntry->type == ADMIN_ENTRY_TYPE_OBSERVATION);
+    LE_ASSERT(obsEntry->u.resourcePtr != NULL);
 
-    res_ReadBufferJson(obsEntry->resourcePtr, startAfter, outputFile, handlerPtr, contextPtr);
+    res_ReadBufferJson(obsEntry->u.resourcePtr, startAfter, outputFile, handlerPtr, contextPtr);
 }
 
 
@@ -1672,10 +1756,10 @@ dataSample_Ref_t resTree_FindBufferedSampleAfter
 )
 //--------------------------------------------------------------------------------------------------
 {
-    LE_ASSERT(obsEntry->resourcePtr != NULL);
     LE_ASSERT(obsEntry->type == ADMIN_ENTRY_TYPE_OBSERVATION);
+    LE_ASSERT(obsEntry->u.resourcePtr != NULL);
 
-    return res_FindBufferedSampleAfter(obsEntry->resourcePtr, startAfter);
+    return res_FindBufferedSampleAfter(obsEntry->u.resourcePtr, startAfter);
 }
 
 
@@ -1691,9 +1775,10 @@ void resTree_SetJsonExample
 )
 //--------------------------------------------------------------------------------------------------
 {
-    LE_ASSERT(resEntry->resourcePtr != NULL);
+    LE_ASSERT(resEntry->type != ADMIN_ENTRY_TYPE_NAMESPACE);
+    LE_ASSERT(resEntry->u.resourcePtr != NULL);
 
-    res_SetJsonExample(resEntry->resourcePtr, example);
+    res_SetJsonExample(resEntry->u.resourcePtr, example);
 }
 
 
@@ -1710,9 +1795,10 @@ dataSample_Ref_t resTree_GetJsonExample
 )
 //--------------------------------------------------------------------------------------------------
 {
-    LE_ASSERT(resEntry->resourcePtr != NULL);
+    LE_ASSERT(resEntry->type != ADMIN_ENTRY_TYPE_NAMESPACE);
+    LE_ASSERT(resEntry->u.resourcePtr != NULL);
 
-    return res_GetJsonExample(resEntry->resourcePtr);
+    return res_GetJsonExample(resEntry->u.resourcePtr);
 }
 
 
@@ -1732,7 +1818,6 @@ void resTree_SetJsonExtraction
 )
 //--------------------------------------------------------------------------------------------------
 {
-    LE_ASSERT(resEntry->resourcePtr != NULL);
 
     if (resEntry->type != ADMIN_ENTRY_TYPE_OBSERVATION)
     {
@@ -1740,7 +1825,8 @@ void resTree_SetJsonExtraction
     }
     else
     {
-        res_SetJsonExtraction(resEntry->resourcePtr, extractionSpec);
+        LE_ASSERT(resEntry->u.resourcePtr != NULL);
+        res_SetJsonExtraction(resEntry->u.resourcePtr, extractionSpec);
     }
 }
 
@@ -1759,15 +1845,14 @@ const char* resTree_GetJsonExtraction
 )
 //--------------------------------------------------------------------------------------------------
 {
-    LE_ASSERT(resEntry->resourcePtr != NULL);
-
     if (resEntry->type != ADMIN_ENTRY_TYPE_OBSERVATION)
     {
         LE_DEBUG("Not an observation (actually a %s).", hub_GetEntryTypeName(resEntry->type));
         return "";
     }
 
-    return res_GetJsonExtraction(resEntry->resourcePtr);
+    LE_ASSERT(resEntry->u.resourcePtr != NULL);
+    return res_GetJsonExtraction(resEntry->u.resourcePtr);
 }
 
 
@@ -1787,14 +1872,13 @@ double resTree_QueryMin
 )
 //--------------------------------------------------------------------------------------------------
 {
-    LE_ASSERT(obsEntry->resourcePtr != NULL);
-
     if (obsEntry->type != ADMIN_ENTRY_TYPE_OBSERVATION)
     {
         return NAN;
     }
 
-    return res_QueryMin(obsEntry->resourcePtr, startTime);
+    LE_ASSERT(obsEntry->u.resourcePtr != NULL);
+    return res_QueryMin(obsEntry->u.resourcePtr, startTime);
 }
 
 
@@ -1814,14 +1898,13 @@ double resTree_QueryMax
 )
 //--------------------------------------------------------------------------------------------------
 {
-    LE_ASSERT(obsEntry->resourcePtr != NULL);
-
     if (obsEntry->type != ADMIN_ENTRY_TYPE_OBSERVATION)
     {
         return NAN;
     }
 
-    return res_QueryMax(obsEntry->resourcePtr, startTime);
+    LE_ASSERT(obsEntry->u.resourcePtr != NULL);
+    return res_QueryMax(obsEntry->u.resourcePtr, startTime);
 }
 
 
@@ -1841,14 +1924,13 @@ double resTree_QueryMean
 )
 //--------------------------------------------------------------------------------------------------
 {
-    LE_ASSERT(obsEntry->resourcePtr != NULL);
-
     if (obsEntry->type != ADMIN_ENTRY_TYPE_OBSERVATION)
     {
         return NAN;
     }
 
-    return res_QueryMean(obsEntry->resourcePtr, startTime);
+    LE_ASSERT(obsEntry->u.resourcePtr != NULL);
+    return res_QueryMean(obsEntry->u.resourcePtr, startTime);
 }
 
 
@@ -1869,13 +1951,11 @@ double resTree_QueryStdDev
 )
 //--------------------------------------------------------------------------------------------------
 {
-    LE_ASSERT(obsEntry->resourcePtr != NULL);
-
     if (obsEntry->type != ADMIN_ENTRY_TYPE_OBSERVATION)
     {
         return NAN;
     }
 
-    return res_QueryStdDev(obsEntry->resourcePtr, startTime);
+    LE_ASSERT(obsEntry->u.resourcePtr != NULL);
+    return res_QueryStdDev(obsEntry->u.resourcePtr, startTime);
 }
-

--- a/components/dataHub/resTree.c
+++ b/components/dataHub/resTree.c
@@ -866,6 +866,21 @@ ssize_t resTree_GetPath
 
 //--------------------------------------------------------------------------------------------------
 /**
+ * Get the parent of a given entry.
+ *
+ * @return Reference to the parent entry, or NULL if the entry has no parent (root).
+ */
+//--------------------------------------------------------------------------------------------------
+resTree_EntryRef_t resTree_GetParent
+(
+    resTree_EntryRef_t entryRef ///< Node to get the parent of.
+)
+{
+    return entryRef->parentPtr;
+}
+
+//--------------------------------------------------------------------------------------------------
+/**
  * Get the first child of a given entry, optionally including already deleted nodes if they have not
  * been flushed.
  *
@@ -1715,8 +1730,51 @@ bool resTree_IsRelevant
 
 //--------------------------------------------------------------------------------------------------
 /**
+ * Set the node's clear newness flag
+ */
+//--------------------------------------------------------------------------------------------------
+void resTree_SetClearNewnessFlag
+(
+    resTree_EntryRef_t resEntry ///< Resource to update.
+)
+{
+    if (resEntry->type == ADMIN_ENTRY_TYPE_NAMESPACE)
+    {
+        resEntry->u.flags |= RES_FLAG_CLEAR_NEW;
+    }
+    else
+    {
+        res_SetClearNewnessFlag(resEntry->u.resourcePtr);
+    }
+}
+
+//--------------------------------------------------------------------------------------------------
+/**
+ * Get the node's "clear newness" flag.
+ *
+ * @return Whether the node "newness" flag must be cleared at the end of current snapshot
+ */
+//--------------------------------------------------------------------------------------------------
+bool resTree_IsNewnessClearRequired
+(
+    resTree_EntryRef_t resEntry ///< Resource to query.
+)
+{
+    if (resEntry->type == ADMIN_ENTRY_TYPE_NAMESPACE)
+    {
+        return (resEntry->u.flags & RES_FLAG_CLEAR_NEW);
+    }
+    else
+    {
+        return res_IsNewnessClearRequired(resEntry->u.resourcePtr);
+    }
+}
+
+//--------------------------------------------------------------------------------------------------
+/**
  * Mark a node as no longer "new."  New nodes are those that were created after the last snapshot
  * scan of the tree.
+ * Also remove the "clear newness" flag.
  */
 //--------------------------------------------------------------------------------------------------
 void resTree_ClearNewness
@@ -1727,6 +1785,7 @@ void resTree_ClearNewness
     if (resEntry->type == ADMIN_ENTRY_TYPE_NAMESPACE)
     {
         resEntry->u.flags &= ~RES_FLAG_NEW;
+        resEntry->u.flags &= ~RES_FLAG_CLEAR_NEW;
     }
     else
     {
@@ -1933,6 +1992,42 @@ dataSample_Ref_t resTree_FindBufferedSampleAfter
     LE_ASSERT(obsEntry->u.resourcePtr != NULL);
 
     return res_FindBufferedSampleAfter(obsEntry->u.resourcePtr, startAfter);
+}
+
+
+//--------------------------------------------------------------------------------------------------
+/**
+ * Get the resource's "JSON example changed" flag.
+ *
+ * @return whether the resource's JSON example was updated after the last scan.
+ */
+//--------------------------------------------------------------------------------------------------
+bool resTree_IsJsonExampleChanged
+(
+    resTree_EntryRef_t resEntry ///< Resource to poll
+)
+{
+    LE_ASSERT(resEntry->type != ADMIN_ENTRY_TYPE_NAMESPACE);
+    LE_ASSERT(resEntry->u.resourcePtr != NULL);
+
+    return res_IsJsonExampleChanged(resEntry->u.resourcePtr);
+}
+
+
+//--------------------------------------------------------------------------------------------------
+/**
+ * Mark a resource's JSON example as not changed.
+ */
+//--------------------------------------------------------------------------------------------------
+void resTree_ClearJsonExampleChanged
+(
+    resTree_EntryRef_t resEntry ///< Resource to update.
+)
+{
+    LE_ASSERT(resEntry->type != ADMIN_ENTRY_TYPE_NAMESPACE);
+    LE_ASSERT(resEntry->u.resourcePtr != NULL);
+
+    res_ClearJsonExampleChanged(resEntry->u.resourcePtr);
 }
 
 

--- a/components/dataHub/resTree.c
+++ b/components/dataHub/resTree.c
@@ -12,7 +12,7 @@
 #include "resource.h"
 #include "resTree.h"
 #include "adminService.h"
-
+#include "snapshot.h"
 
 //--------------------------------------------------------------------------------------------------
 /**
@@ -54,38 +54,48 @@ static le_mem_PoolRef_t EntryPool = NULL;
 //--------------------------------------------------------------------------------------------------
 static Entry_t* AddChild
 (
-    Entry_t* parentPtr, ///< Ptr to the parent entry (NULL if creating the Root).
-    const char* name    ///< Name of the new child ("" if creating the Root).
+    Entry_t     *parentPtr, ///< Ptr to the parent entry (NULL if creating the Root).
+    const char  *name,      ///< Name of the new child ("" if creating the Root).
+    Entry_t     *entryPtr   ///< If non-NULL, resurrect an existing namespace node as the child,
+                            ///< rather than creating a new one.
 )
 //--------------------------------------------------------------------------------------------------
 {
-    Entry_t* entryPtr = le_mem_ForceAlloc(EntryPool);
-
-    entryPtr->link = LE_DLS_LINK_INIT;
-
-    if (LE_OK != le_utf8_Copy(entryPtr->name, name, sizeof(entryPtr->name), NULL))
+    if (entryPtr == NULL)
     {
-        LE_ERROR("Resource tree entry name longer than %zu bytes max. Truncated to '%s'.",
-                 sizeof(entryPtr->name),
-                 name);
+        entryPtr = le_mem_Alloc(EntryPool);
+
+        if (LE_OK != le_utf8_Copy(entryPtr->name, name, sizeof(entryPtr->name), NULL))
+        {
+            LE_ERROR("Resource tree entry name longer than %zu bytes max. Truncated to '%s'.",
+                     sizeof(entryPtr->name),
+                     name);
+        }
+
+        entryPtr->link = LE_DLS_LINK_INIT;
+        entryPtr->childList = LE_DLS_LIST_INIT;
+        entryPtr->type = ADMIN_ENTRY_TYPE_NAMESPACE;
+
+        if (parentPtr != NULL)
+        {
+            LE_ASSERT(resTree_FindChildEx(parentPtr, name, true) == NULL);
+
+            // Increment the reference count on the parent.
+            le_mem_AddRef(parentPtr);
+
+            // Link to the parent entry.
+            entryPtr->parentPtr = parentPtr;
+            le_dls_Queue(&parentPtr->childList, &entryPtr->link);
+        }
+    }
+    else
+    {
+        LE_ASSERT(entryPtr->type == ADMIN_ENTRY_TYPE_NAMESPACE);
+        LE_ASSERT(entryPtr->parentPtr == parentPtr);
+        LE_ASSERT(le_dls_IsEmpty(&entryPtr->childList));
     }
 
-    entryPtr->childList = LE_DLS_LIST_INIT;
-    entryPtr->type = ADMIN_ENTRY_TYPE_NAMESPACE;
-    entryPtr->u.flags = 0;
-
-    if (parentPtr != NULL)
-    {
-        LE_ASSERT(resTree_FindChild(parentPtr, name) == NULL);
-
-        // Increment the reference count on the parent.
-        le_mem_AddRef(parentPtr);
-
-        // Link to the parent entry.
-        entryPtr->parentPtr = parentPtr;
-        le_dls_Queue(&parentPtr->childList, &entryPtr->link);
-    }
-
+    entryPtr->u.flags = RES_FLAG_NEW;
     return entryPtr;
 }
 
@@ -105,7 +115,6 @@ static void EntryDestructor
 
     LE_ASSERT(entryPtr->parentPtr != NULL);
     LE_ASSERT(le_dls_IsEmpty(&entryPtr->childList));
-    LE_ASSERT(entryPtr->u.flags == 0);
 
     // Remove from parent's list of children.
     le_dls_Remove(&entryPtr->parentPtr->childList, &entryPtr->link);
@@ -133,7 +142,7 @@ void resTree_Init
     le_mem_SetDestructor(EntryPool, EntryDestructor);
 
     // Create the Root Namespace.
-    RootPtr = AddChild(NULL, "");
+    RootPtr = AddChild(NULL, "", NULL);
 }
 
 
@@ -177,6 +186,41 @@ resTree_EntryRef_t resTree_GetRoot
     return RootPtr;
 }
 
+//--------------------------------------------------------------------------------------------------
+/**
+ * Find a child entry with a given name, optionally including already deleted nodes if they have not
+ * been flushed.
+ *
+ * @return Reference to the object or NULL if not found.
+ */
+//--------------------------------------------------------------------------------------------------
+resTree_EntryRef_t resTree_FindChildEx
+(
+    resTree_EntryRef_t   nsRef,         ///< Namespace entry to search.
+    const char          *name,          ///< Name of the child entry.
+    bool                 withZombies    ///< If the child has been deleted but is still around,
+                                        ///< return it.
+)
+{
+    le_dls_Link_t* linkPtr = le_dls_Peek(&nsRef->childList);
+
+    while (linkPtr != NULL)
+    {
+        Entry_t* childPtr = CONTAINER_OF(linkPtr, Entry_t, link);
+
+        if (withZombies || !resTree_IsDeleted(childPtr))
+        {
+            if (strncmp(name, childPtr->name, sizeof(childPtr->name)) == 0)
+            {
+                return childPtr;
+            }
+        }
+
+        linkPtr = le_dls_PeekNext(&nsRef->childList, linkPtr);
+    }
+
+    return NULL;
+}
 
 //--------------------------------------------------------------------------------------------------
 /**
@@ -192,21 +236,7 @@ resTree_EntryRef_t resTree_FindChild
 )
 //--------------------------------------------------------------------------------------------------
 {
-    le_dls_Link_t* linkPtr = le_dls_Peek(&nsRef->childList);
-
-    while (linkPtr != NULL)
-    {
-        Entry_t* childPtr = CONTAINER_OF(linkPtr, Entry_t, link);
-
-        if (strcmp(name, childPtr->name) == 0)
-        {
-            return childPtr;
-        }
-
-        linkPtr = le_dls_PeekNext(&nsRef->childList, linkPtr);
-    }
-
-    return NULL;
+    return resTree_FindChildEx(nsRef, name, false);
 }
 
 
@@ -275,15 +305,15 @@ static resTree_EntryRef_t GoToEntry
 
         // Look up the entry name in the list of children of the current entry.
         // If found, this becomes the new current entry.
-        Entry_t* childPtr = resTree_FindChild(currentEntry, entryName);
+        Entry_t* childPtr = resTree_FindChildEx(currentEntry, entryName, true);
 
-        if (childPtr == NULL)
+        if (childPtr == NULL || resTree_IsDeleted(childPtr))
         {
             // If we're supposed to create a missing entry, create one now.
             // Otherwise, return NULL.
             if (doCreate)
             {
-                childPtr = AddChild(currentEntry, entryName);
+                childPtr = AddChild(currentEntry, entryName, childPtr);
             }
             else
             {
@@ -834,6 +864,35 @@ ssize_t resTree_GetPath
     return bytesWritten;
 }
 
+//--------------------------------------------------------------------------------------------------
+/**
+ * Get the first child of a given entry, optionally including already deleted nodes if they have not
+ * been flushed.
+ *
+ * @return Reference to the first child entry, or NULL if the entry has no children.
+ */
+//--------------------------------------------------------------------------------------------------
+resTree_EntryRef_t resTree_GetFirstChildEx
+(
+    resTree_EntryRef_t  entryRef,   ///< Node to get the child of.
+    bool                withZombies ///< If the child has been deleted but is still around, return
+                                    ///< it.
+)
+{
+    le_dls_Link_t       *linkPtr = le_dls_Peek(&entryRef->childList);
+    resTree_EntryRef_t   childPtr;
+
+    if (linkPtr != NULL)
+    {
+        childPtr = CONTAINER_OF(linkPtr, Entry_t, link);
+        if (withZombies || !resTree_IsDeleted(childPtr))
+        {
+            return childPtr;
+        }
+    }
+
+    return NULL;
+}
 
 //--------------------------------------------------------------------------------------------------
 /**
@@ -848,16 +907,45 @@ resTree_EntryRef_t resTree_GetFirstChild
 )
 //--------------------------------------------------------------------------------------------------
 {
-    le_dls_Link_t* linkPtr = le_dls_Peek(&entryRef->childList);
+    return resTree_GetFirstChildEx(entryRef, false);
+}
+
+//--------------------------------------------------------------------------------------------------
+/**
+ * Get the next sibling (child of the same parent) of a given entry, optionally including already
+ * deleted nodes if they have not been flushed.
+ *
+ * @return Reference to the next entry in the parent's child list, or
+ *         NULL if already at the last child.
+ */
+//--------------------------------------------------------------------------------------------------
+resTree_EntryRef_t resTree_GetNextSiblingEx
+(
+    resTree_EntryRef_t  entryRef,   ///< Node to get the sibling of.
+    bool                withZombies ///< If the sibling has been deleted but is still around, return
+                                    ///< it.
+)
+{
+    if (entryRef->parentPtr == NULL)
+    {
+        // Someone called this function for the Root entry.
+        return NULL;
+    }
+
+    le_dls_Link_t       *linkPtr = le_dls_PeekNext(&entryRef->parentPtr->childList, &entryRef->link);
+    resTree_EntryRef_t   childPtr;
 
     if (linkPtr != NULL)
     {
-        return CONTAINER_OF(linkPtr, Entry_t, link);
+        childPtr = CONTAINER_OF(linkPtr, Entry_t, link);
+        if (withZombies || !resTree_IsDeleted(childPtr))
+        {
+            return childPtr;
+        }
     }
 
     return NULL;
 }
-
 
 //--------------------------------------------------------------------------------------------------
 /**
@@ -873,20 +961,7 @@ resTree_EntryRef_t resTree_GetNextSibling
 )
 //--------------------------------------------------------------------------------------------------
 {
-    if (entryRef->parentPtr == NULL)
-    {
-        // Someone called this function for the Root entry.
-        return NULL;
-    }
-
-    le_dls_Link_t* linkPtr = le_dls_PeekNext(&entryRef->parentPtr->childList, &entryRef->link);
-
-    if (linkPtr != NULL)
-    {
-        return CONTAINER_OF(linkPtr, Entry_t, link);
-    }
-
-    return NULL;
+    return resTree_GetNextSiblingEx(entryRef, false);
 }
 
 
@@ -1060,8 +1135,10 @@ void resTree_DeleteIO
         // Release the IO resource.
         le_mem_Release(ioPtr);
 
+        // Record the deletion.
+        snapshot_RecordNodeDeletion(entryRef);
+
         // Release the resource tree entry.
-        // This will cause it to be removed from the resource tree.
         le_mem_Release(entryRef);
     }
 }
@@ -1087,8 +1164,10 @@ void resTree_DeleteObservation
     obsEntry->u.flags = 0;
     obsEntry->type = ADMIN_ENTRY_TYPE_NAMESPACE;
 
-    // Release the namespace (resource tree entry).  This will cause it to be removed from the
-    // resource tree.
+    // Record the deletion.
+    snapshot_RecordNodeDeletion(obsEntry);
+
+    // Release the namespace (resource tree entry).
     le_mem_Release(obsEntry);
 }
 
@@ -1597,7 +1676,14 @@ void resTree_SetRelevance
 {
     if (resEntry->type == ADMIN_ENTRY_TYPE_NAMESPACE)
     {
-        resEntry->u.flags |= RES_FLAG_RELEVANT;
+        if (relevant)
+        {
+            resEntry->u.flags |= RES_FLAG_RELEVANT;
+        }
+        else
+        {
+            resEntry->u.flags &= ~RES_FLAG_RELEVANT;
+        }
     }
     else
     {
@@ -1624,6 +1710,93 @@ bool resTree_IsRelevant
     else
     {
         return res_IsRelevant(resEntry->u.resourcePtr);
+    }
+}
+
+//--------------------------------------------------------------------------------------------------
+/**
+ * Mark a node as no longer "new."  New nodes are those that were created after the last snapshot
+ * scan of the tree.
+ */
+//--------------------------------------------------------------------------------------------------
+void resTree_ClearNewness
+(
+    resTree_EntryRef_t resEntry ///< Resource to update.
+)
+{
+    if (resEntry->type == ADMIN_ENTRY_TYPE_NAMESPACE)
+    {
+        resEntry->u.flags &= ~RES_FLAG_NEW;
+    }
+    else
+    {
+        res_ClearNewness(resEntry->u.resourcePtr);
+    }
+}
+
+//--------------------------------------------------------------------------------------------------
+/**
+ * Get the node's "newness" flag.
+ *
+ * @return Whether the node was created after the last scan.
+ */
+//--------------------------------------------------------------------------------------------------
+bool resTree_IsNew
+(
+    resTree_EntryRef_t resEntry ///< Resource to query.
+)
+{
+    if (resEntry->type == ADMIN_ENTRY_TYPE_NAMESPACE)
+    {
+        return (resEntry->u.flags & RES_FLAG_NEW);
+    }
+    else
+    {
+        return res_IsNew(resEntry->u.resourcePtr);
+    }
+}
+
+//--------------------------------------------------------------------------------------------------
+/**
+ * Mark a node as deleted.
+ */
+//--------------------------------------------------------------------------------------------------
+void resTree_SetDeleted
+(
+    resTree_EntryRef_t resEntry ///< Resource to update.
+)
+{
+    // The deleted flag should only be set on nodes which have already been converted to namespaces
+    // as part of the deletion cleanup process.
+    LE_ASSERT(resEntry->type == ADMIN_ENTRY_TYPE_NAMESPACE);
+    // The deletion flag should not be set on nodes which have not been scanned yet, as there is no
+    // point in keeping them around as a deletion record.
+    LE_ASSERT((resEntry->u.flags & RES_FLAG_NEW) == 0);
+
+    resEntry->u.flags |= RES_FLAG_DELETED;
+}
+
+//--------------------------------------------------------------------------------------------------
+/**
+ * Get the node's "deleted" flag.
+ *
+ * @return Whether the node was deleted after the last flush.
+ */
+//--------------------------------------------------------------------------------------------------
+bool resTree_IsDeleted
+(
+    resTree_EntryRef_t resEntry ///< Resource to query.
+)
+{
+    if (resEntry->type == ADMIN_ENTRY_TYPE_NAMESPACE)
+    {
+        return (resEntry->u.flags & RES_FLAG_DELETED);
+    }
+    else
+    {
+        // All deleted nodes are converted to namespaces during the deletion process, so if it is
+        // not a namespace, it can't be considered deleted.
+        return false;
     }
 }
 

--- a/components/dataHub/resTree.h
+++ b/components/dataHub/resTree.h
@@ -74,6 +74,21 @@ bool resTree_IsResource
     resTree_EntryRef_t entryRef
 );
 
+//--------------------------------------------------------------------------------------------------
+/**
+ * Find a child entry with a given name, optionally including already deleted nodes if they have not
+ * been flushed.
+ *
+ * @return Reference to the object or NULL if not found.
+ */
+//--------------------------------------------------------------------------------------------------
+resTree_EntryRef_t resTree_FindChildEx
+(
+    resTree_EntryRef_t   nsRef,         ///< Namespace entry to search.
+    const char          *name,          ///< Name of the child entry.
+    bool                 withZombies    ///< If the child has been deleted but is still around,
+                                        ///< return it.
+);
 
 //--------------------------------------------------------------------------------------------------
 /**
@@ -293,6 +308,20 @@ LE_SHARED ssize_t resTree_GetPath
     resTree_EntryRef_t entryRef
 );
 
+//--------------------------------------------------------------------------------------------------
+/**
+ * Get the first child of a given entry, optionally including already deleted nodes if they have not
+ * been flushed.
+ *
+ * @return Reference to the first child entry, or NULL if the entry has no children.
+ */
+//--------------------------------------------------------------------------------------------------
+resTree_EntryRef_t resTree_GetFirstChildEx
+(
+    resTree_EntryRef_t  entryRef,   ///< Node to get the child of.
+    bool                withZombies ///< If the child has been deleted but is still around, return
+                                    ///< it.
+);
 
 //--------------------------------------------------------------------------------------------------
 /**
@@ -301,11 +330,26 @@ LE_SHARED ssize_t resTree_GetPath
  * @return Reference to the first child entry, or NULL if the entry has no children.
  */
 //--------------------------------------------------------------------------------------------------
-resTree_EntryRef_t resTree_GetFirstChild
+LE_SHARED resTree_EntryRef_t resTree_GetFirstChild
 (
     resTree_EntryRef_t entryRef
 );
 
+//--------------------------------------------------------------------------------------------------
+/**
+ * Get the next sibling (child of the same parent) of a given entry, optionally including already
+ * deleted nodes if they have not been flushed.
+ *
+ * @return Reference to the next entry in the parent's child list, or
+ *         NULL if already at the last child.
+ */
+//--------------------------------------------------------------------------------------------------
+resTree_EntryRef_t resTree_GetNextSiblingEx
+(
+    resTree_EntryRef_t  entryRef,   ///< Node to get the sibling of.
+    bool                withZombies ///< If the sibling has been deleted but is still around, return
+                                    ///< it.
+);
 
 //--------------------------------------------------------------------------------------------------
 /**
@@ -317,7 +361,7 @@ resTree_EntryRef_t resTree_GetFirstChild
  * @warning Do not call this for the Root Entry.
  */
 //--------------------------------------------------------------------------------------------------
-resTree_EntryRef_t resTree_GetNextSibling
+LE_SHARED resTree_EntryRef_t resTree_GetNextSibling
 (
     resTree_EntryRef_t entryRef
 );
@@ -816,6 +860,51 @@ void resTree_SetRelevance
  */
 //--------------------------------------------------------------------------------------------------
 bool resTree_IsRelevant
+(
+    resTree_EntryRef_t resEntry ///< Resource to query.
+);
+
+//--------------------------------------------------------------------------------------------------
+/**
+ * Mark a node as no longer "new."  New nodes are those that were created after the last snapshot
+ * scan of the tree.
+ */
+//--------------------------------------------------------------------------------------------------
+void resTree_ClearNewness
+(
+    resTree_EntryRef_t resEntry ///< Resource to update.
+);
+
+//--------------------------------------------------------------------------------------------------
+/**
+ * Get the node's "newness" flag.
+ *
+ * @return Whether the node was created after the last scan.
+ */
+//--------------------------------------------------------------------------------------------------
+LE_SHARED bool resTree_IsNew
+(
+    resTree_EntryRef_t resEntry ///< Resource to query.
+);
+
+//--------------------------------------------------------------------------------------------------
+/**
+ * Mark a node as deleted.
+ */
+//--------------------------------------------------------------------------------------------------
+void resTree_SetDeleted
+(
+    resTree_EntryRef_t resEntry ///< Resource to update.
+);
+
+//--------------------------------------------------------------------------------------------------
+/**
+ * Get the node's "deleted" flag.
+ *
+ * @return Whether the node was deleted after the last flush.
+ */
+//--------------------------------------------------------------------------------------------------
+LE_SHARED bool resTree_IsDeleted
 (
     resTree_EntryRef_t resEntry ///< Resource to query.
 );

--- a/components/dataHub/resTree.h
+++ b/components/dataHub/resTree.h
@@ -56,7 +56,7 @@ void resTree_Init
  * @return Reference to the object.
  */
 //--------------------------------------------------------------------------------------------------
-resTree_EntryRef_t resTree_GetRoot
+LE_SHARED resTree_EntryRef_t resTree_GetRoot
 (
     void
 );
@@ -123,7 +123,7 @@ resTree_EntryRef_t resTree_FindEntryAtAbsolutePath
  * @return Ptr to the name. Only valid while the entry exists.
  */
 //--------------------------------------------------------------------------------------------------
-const char* resTree_GetEntryName
+LE_SHARED const char *resTree_GetEntryName
 (
     resTree_EntryRef_t entryRef
 );
@@ -136,7 +136,7 @@ const char* resTree_GetEntryName
  * @return The entry type.
  */
 //--------------------------------------------------------------------------------------------------
-admin_EntryType_t resTree_GetEntryType
+LE_SHARED admin_EntryType_t resTree_GetEntryType
 (
     resTree_EntryRef_t entryRef
 );
@@ -165,7 +165,7 @@ const char* resTree_GetUnits
  * @return the data type.
  */
 //--------------------------------------------------------------------------------------------------
-io_DataType_t resTree_GetDataType
+LE_SHARED io_DataType_t resTree_GetDataType
 (
     resTree_EntryRef_t resRef
 );
@@ -285,7 +285,7 @@ resTree_EntryRef_t resTree_GetObservation
  *  - LE_NOT_FOUND if the resource is not in the given namespace.
  */
 //--------------------------------------------------------------------------------------------------
-ssize_t resTree_GetPath
+LE_SHARED ssize_t resTree_GetPath
 (
     char* stringBuffPtr,  ///< Ptr to where the path should be written.
     size_t stringBuffSize,  ///< Size of the string buffer, in bytes.
@@ -363,7 +363,7 @@ hub_HandlerRef_t resTree_AddPushHandler
  * @return Reference to the Data Sample object or NULL if the resource doesn't have a current value.
  */
 //--------------------------------------------------------------------------------------------------
-dataSample_Ref_t resTree_GetCurrentValue
+LE_SHARED dataSample_Ref_t resTree_GetCurrentValue
 (
     resTree_EntryRef_t resRef
 );
@@ -648,7 +648,7 @@ void resTree_MarkOptional
  * @return true if a mandatory output, false if it's an optional output or not an output at all.
  */
 //--------------------------------------------------------------------------------------------------
-bool resTree_IsMandatory
+LE_SHARED bool resTree_IsMandatory
 (
     resTree_EntryRef_t resEntry
 );
@@ -785,6 +785,40 @@ void resTree_RemoveOverride
     resTree_EntryRef_t resEntry
 );
 
+//--------------------------------------------------------------------------------------------------
+/**
+ * Get the last modified time stamp of a resource.
+ *
+ * @return Time stamp value, in seconds since the Epoch.
+ */
+//--------------------------------------------------------------------------------------------------
+double resTree_GetLastModified
+(
+    resTree_EntryRef_t resEntry ///< Resource to query.
+);
+
+//--------------------------------------------------------------------------------------------------
+/**
+ * Set the node's relevance flag.
+ */
+//--------------------------------------------------------------------------------------------------
+void resTree_SetRelevance
+(
+    resTree_EntryRef_t  resEntry,   ///< Resource to query.
+    bool                relevant    ///< Relevance of node to current operation.
+);
+
+//--------------------------------------------------------------------------------------------------
+/**
+ * Get the node's relevance flag.
+ *
+ * @return Relevance of node to the current operation.
+ */
+//--------------------------------------------------------------------------------------------------
+bool resTree_IsRelevant
+(
+    resTree_EntryRef_t resEntry ///< Resource to query.
+);
 
 //--------------------------------------------------------------------------------------------------
 /**
@@ -983,6 +1017,5 @@ double resTree_QueryStdDev
     resTree_EntryRef_t obsEntry,    ///< Observation entry.
     double startTime    ///< If < 30 years then seconds before now; else seconds since the Epoch.
 );
-
 
 #endif // NAMESPACE_H_INCLUDE_GUARD

--- a/components/dataHub/resTree.h
+++ b/components/dataHub/resTree.h
@@ -310,6 +310,18 @@ LE_SHARED ssize_t resTree_GetPath
 
 //--------------------------------------------------------------------------------------------------
 /**
+ * Get the parent of a given entry.
+ *
+ * @return Reference to the parent entry, or NULL if the entry has no parent (root).
+ */
+//--------------------------------------------------------------------------------------------------
+LE_SHARED resTree_EntryRef_t resTree_GetParent
+(
+    resTree_EntryRef_t entryRef ///< Node to get the parent of.
+);
+
+//--------------------------------------------------------------------------------------------------
+/**
  * Get the first child of a given entry, optionally including already deleted nodes if they have not
  * been flushed.
  *
@@ -721,7 +733,7 @@ void resTree_SetDefault
  * @return true if there is a default value set, false if not.
  */
 //--------------------------------------------------------------------------------------------------
-bool resTree_HasDefault
+LE_SHARED bool resTree_HasDefault
 (
     resTree_EntryRef_t resEntry
 );
@@ -734,7 +746,7 @@ bool resTree_HasDefault
  * @return The data type, or IO_DATA_TYPE_TRIGGER if not set.
  */
 //--------------------------------------------------------------------------------------------------
-io_DataType_t resTree_GetDefaultDataType
+LE_SHARED io_DataType_t resTree_GetDefaultDataType
 (
     resTree_EntryRef_t resEntry
 );
@@ -747,7 +759,7 @@ io_DataType_t resTree_GetDefaultDataType
  * @return the default value, or NULL if not set.
  */
 //--------------------------------------------------------------------------------------------------
-dataSample_Ref_t resTree_GetDefaultValue
+LE_SHARED dataSample_Ref_t resTree_GetDefaultValue
 (
     resTree_EntryRef_t resEntry
 );
@@ -860,6 +872,28 @@ void resTree_SetRelevance
  */
 //--------------------------------------------------------------------------------------------------
 bool resTree_IsRelevant
+(
+    resTree_EntryRef_t resEntry ///< Resource to query.
+);
+
+//--------------------------------------------------------------------------------------------------
+/**
+ * Set the node's clear newness flag
+ */
+//--------------------------------------------------------------------------------------------------
+void resTree_SetClearNewnessFlag
+(
+    resTree_EntryRef_t resEntry ///< Resource to update.
+);
+
+//--------------------------------------------------------------------------------------------------
+/**
+ * Get the node's "clear newness" flag.
+ *
+ * @return Whether the node "newness" flag must be cleared at the end of current snapshot
+ */
+//--------------------------------------------------------------------------------------------------
+bool resTree_IsNewnessClearRequired
 (
     resTree_EntryRef_t resEntry ///< Resource to query.
 );
@@ -990,6 +1024,30 @@ dataSample_Ref_t resTree_FindBufferedSampleAfter
 
 //--------------------------------------------------------------------------------------------------
 /**
+ * Get the resource's "JSON example changed" flag.
+ *
+ * @return whether the resource's JSON example was updated after the last scan.
+ */
+//--------------------------------------------------------------------------------------------------
+LE_SHARED bool resTree_IsJsonExampleChanged
+(
+    resTree_EntryRef_t resEntry ///< Resource to poll
+);
+
+
+//--------------------------------------------------------------------------------------------------
+/**
+ * Mark a resource's JSON example as not changed.
+ */
+//--------------------------------------------------------------------------------------------------
+LE_SHARED void resTree_ClearJsonExampleChanged
+(
+    resTree_EntryRef_t resEntry ///< Resource to update.
+);
+
+
+//--------------------------------------------------------------------------------------------------
+/**
  * Set the JSON example value for a given resource.
  */
 //--------------------------------------------------------------------------------------------------
@@ -1007,7 +1065,7 @@ void resTree_SetJsonExample
  * @return A reference to the example value or NULL if no example set.
  */
 //--------------------------------------------------------------------------------------------------
-dataSample_Ref_t resTree_GetJsonExample
+LE_SHARED dataSample_Ref_t resTree_GetJsonExample
 (
     resTree_EntryRef_t resEntry
 );

--- a/components/dataHub/resource.c
+++ b/components/dataHub/resource.c
@@ -1521,6 +1521,34 @@ bool res_IsRelevant
 
 //--------------------------------------------------------------------------------------------------
 /**
+ * Set the resource's clear newness flag
+ */
+//--------------------------------------------------------------------------------------------------
+void res_SetClearNewnessFlag
+(
+    res_Resource_t  *resPtr ///< Resource to query.
+)
+{
+    resPtr->flags |= RES_FLAG_CLEAR_NEW;
+}
+
+//--------------------------------------------------------------------------------------------------
+/**
+ * Get the resource's "clear newness" flag.
+ *
+ * @return Whether the resource "newness" flag must be cleared at the end of current snapshot
+ */
+//--------------------------------------------------------------------------------------------------
+bool res_IsNewnessClearRequired
+(
+    res_Resource_t  *resPtr ///< Resource to query.
+)
+{
+    return (resPtr->flags & RES_FLAG_CLEAR_NEW);
+}
+
+//--------------------------------------------------------------------------------------------------
+/**
  * Mark a resource as no longer "new."  "New" resources are those that were created after the last
  * snapshot scan of the tree.
  */
@@ -1531,6 +1559,7 @@ void res_ClearNewness
 )
 {
     resPtr->flags &= ~RES_FLAG_NEW;
+    resPtr->flags &= ~RES_FLAG_CLEAR_NEW;
 }
 
 //--------------------------------------------------------------------------------------------------
@@ -1655,6 +1684,36 @@ dataSample_Ref_t res_FindBufferedSampleAfter
 
 //--------------------------------------------------------------------------------------------------
 /**
+ * Get the resource's "JSON example changed" flag.
+ *
+ * @return whether the resource's JSON example was updated after the last scan.
+ */
+//--------------------------------------------------------------------------------------------------
+bool res_IsJsonExampleChanged
+(
+    res_Resource_t* resPtr
+)
+{
+    return (resPtr->flags & RES_FLAG_JSON_EX_CHANGED);
+}
+
+
+//--------------------------------------------------------------------------------------------------
+/**
+ * Mark a resource's JSON example as not changed.
+ */
+//--------------------------------------------------------------------------------------------------
+void res_ClearJsonExampleChanged
+(
+    res_Resource_t *resPtr ///< Resource to update.
+)
+{
+    resPtr->flags &= ~RES_FLAG_JSON_EX_CHANGED;
+}
+
+
+//--------------------------------------------------------------------------------------------------
+/**
  * Set the JSON example value for a given resource.
  */
 //--------------------------------------------------------------------------------------------------
@@ -1671,6 +1730,7 @@ void res_SetJsonExample
     }
 
     resPtr->jsonExample = example;
+    resPtr->flags |= RES_FLAG_JSON_EX_CHANGED;
 
     // Iterate over the list of destination routes, setting their JSON example values.
     le_dls_Link_t* linkPtr = le_dls_Peek(&(resPtr->destList));

--- a/components/dataHub/resource.c
+++ b/components/dataHub/resource.c
@@ -131,7 +131,7 @@ void res_Construct
     resPtr->overrideType = IO_DATA_TYPE_TRIGGER;
     resPtr->defaultValue = NULL;
     resPtr->defaultType = IO_DATA_TYPE_TRIGGER;
-    resPtr->flags = 0;
+    resPtr->flags = RES_FLAG_NEW;
     resPtr->pushHandlerList = LE_DLS_LIST_INIT;
     resPtr->jsonExample = NULL;
 }
@@ -1517,6 +1517,35 @@ bool res_IsRelevant
 )
 {
     return (resPtr->flags & RES_FLAG_RELEVANT);
+}
+
+//--------------------------------------------------------------------------------------------------
+/**
+ * Mark a resource as no longer "new."  "New" resources are those that were created after the last
+ * snapshot scan of the tree.
+ */
+//--------------------------------------------------------------------------------------------------
+void res_ClearNewness
+(
+    res_Resource_t *resPtr ///< Resource to query.
+)
+{
+    resPtr->flags &= ~RES_FLAG_NEW;
+}
+
+//--------------------------------------------------------------------------------------------------
+/**
+ * Get the resource's "newness" flag.
+ *
+ * @return Whether the resource was created after the last scan.
+ */
+//--------------------------------------------------------------------------------------------------
+bool res_IsNew
+(
+    res_Resource_t *resPtr ///< Resource to query.
+)
+{
+    return (resPtr->flags & RES_FLAG_NEW);
 }
 
 //--------------------------------------------------------------------------------------------------

--- a/components/dataHub/resource.c
+++ b/components/dataHub/resource.c
@@ -131,7 +131,7 @@ void res_Construct
     resPtr->overrideType = IO_DATA_TYPE_TRIGGER;
     resPtr->defaultValue = NULL;
     resPtr->defaultType = IO_DATA_TYPE_TRIGGER;
-    resPtr->isConfigChanging = false;
+    resPtr->flags = 0;
     resPtr->pushHandlerList = LE_DLS_LIST_INIT;
     resPtr->jsonExample = NULL;
 }
@@ -427,8 +427,8 @@ le_result_t res_SetSource
         // should be suspended until the update finishes.
         if (IsUpdateInProgress)
         {
-            srcPtr->isConfigChanging = true;
-            destPtr->isConfigChanging = true;
+            srcPtr->flags |= RES_FLAG_CHANGING_CONFIG;
+            destPtr->flags |= RES_FLAG_CHANGING_CONFIG;
         }
     }
     // If the source is being set to a NULL source (removing the source) and the resource is
@@ -603,7 +603,7 @@ void res_Push
 
     // If the resource is undergoing a change to its routing or filtering configuration,
     // then acceptance of new samples is suspended until the configuration change is done.
-    if (resPtr->isConfigChanging)
+    if (resPtr->flags & RES_FLAG_CHANGING_CONFIG)
     {
         LE_WARN("Rejecting pushed value because configuration update is in progress.");
         le_mem_Release(dataSample);
@@ -815,8 +815,8 @@ void res_MoveAdminSettings
     destPtr->defaultValue = srcPtr->defaultValue;
     srcPtr->defaultValue = NULL;
 
-    // Move the isConfigChanging flag.
-    destPtr->isConfigChanging = srcPtr->isConfigChanging;
+    // Move the flags.
+    destPtr->flags = srcPtr->flags;
 
     // Move the push handler list.
     handler_MoveAll(&destPtr->pushHandlerList, &srcPtr->pushHandlerList);
@@ -918,7 +918,7 @@ void res_SetMinPeriod
 
     if (IsUpdateInProgress)
     {
-        resPtr->isConfigChanging = true;
+        resPtr->flags |= RES_FLAG_CHANGING_CONFIG;
     }
 }
 
@@ -958,7 +958,7 @@ void res_SetHighLimit
 
     if (IsUpdateInProgress)
     {
-        resPtr->isConfigChanging = true;
+        resPtr->flags |= RES_FLAG_CHANGING_CONFIG;
     }
 }
 
@@ -998,7 +998,7 @@ void res_SetLowLimit
 
     if (IsUpdateInProgress)
     {
-        resPtr->isConfigChanging = true;
+        resPtr->flags |= RES_FLAG_CHANGING_CONFIG;
     }
 }
 
@@ -1041,7 +1041,7 @@ void res_SetChangeBy
 
     if (IsUpdateInProgress)
     {
-        resPtr->isConfigChanging = true;
+        resPtr->flags |= RES_FLAG_CHANGING_CONFIG;
     }
 }
 
@@ -1085,7 +1085,7 @@ void res_SetTransform
 
     if (IsUpdateInProgress)
     {
-        resPtr->isConfigChanging = true;
+        resPtr->flags |= RES_FLAG_CHANGING_CONFIG;
     }
 }
 
@@ -1483,6 +1483,41 @@ void res_RemoveOverride
     }
 }
 
+//--------------------------------------------------------------------------------------------------
+/**
+ * Set the resource's relevance flag.
+ */
+//--------------------------------------------------------------------------------------------------
+void res_SetRelevance
+(
+    res_Resource_t  *resPtr,    ///< Resource to query.
+    bool             relevant   ///< Relevance of resource to current operation.
+)
+{
+    if (relevant)
+    {
+        resPtr->flags |= RES_FLAG_RELEVANT;
+    }
+    else
+    {
+        resPtr->flags &= ~RES_FLAG_RELEVANT;
+    }
+}
+
+//--------------------------------------------------------------------------------------------------
+/**
+ * Get the resource's relevance flag.
+ *
+ * @return Relevance of resource to the current operation.
+ */
+//--------------------------------------------------------------------------------------------------
+bool res_IsRelevant
+(
+    res_Resource_t *resPtr ///< Resource to query.
+)
+{
+    return (resPtr->flags & RES_FLAG_RELEVANT);
+}
 
 //--------------------------------------------------------------------------------------------------
 /**
@@ -1506,7 +1541,7 @@ void res_StartUpdate
 
 //--------------------------------------------------------------------------------------------------
 /**
- * Clear the isConfigChanging flag on a given resource.
+ * Clear the config changing flag on a given resource.
  */
 //--------------------------------------------------------------------------------------------------
 static void ClearConfigChangingFlag
@@ -1516,7 +1551,8 @@ static void ClearConfigChangingFlag
 )
 //--------------------------------------------------------------------------------------------------
 {
-    resPtr->isConfigChanging = false;
+    LE_UNUSED(entryType);
+    resPtr->flags &= ~RES_FLAG_CHANGING_CONFIG;
 }
 
 

--- a/components/dataHub/resource.h
+++ b/components/dataHub/resource.h
@@ -12,6 +12,9 @@
 
 #define RES_FLAG_CHANGING_CONFIG    0x80000000  ///< Administrative config update in progress.
 #define RES_FLAG_RELEVANT           0x40000000  ///< Resource is relevant to current operation.
+#define RES_FLAG_NEW                0x20000000  ///< Node has been created since the last snapshot.
+#define RES_FLAG_DELETED            0x10000000  ///< Node has been deleted since deletions were last
+                                                ///< flushed.
 
 // Forward declaration needed by res_Resource_t.entryRef.  See resTree.h
 typedef struct resTree_Entry* resTree_EntryRef_t;
@@ -724,6 +727,29 @@ void res_SetRelevance
  */
 //--------------------------------------------------------------------------------------------------
 bool res_IsRelevant
+(
+    res_Resource_t *resPtr ///< Resource to query.
+);
+
+//--------------------------------------------------------------------------------------------------
+/**
+ * Mark a resource as no longer "new."  "New" resources are those that were created after the last
+ * snapshot scan of the tree.
+ */
+//--------------------------------------------------------------------------------------------------
+void res_ClearNewness
+(
+    res_Resource_t *resPtr ///< Resource to update.
+);
+
+//--------------------------------------------------------------------------------------------------
+/**
+ * Get the resource's "newness" flag.
+ *
+ * @return Whether the resource was created after the last scan.
+ */
+//--------------------------------------------------------------------------------------------------
+bool res_IsNew
 (
     res_Resource_t *resPtr ///< Resource to query.
 );

--- a/components/dataHub/resource.h
+++ b/components/dataHub/resource.h
@@ -10,6 +10,8 @@
 #ifndef RESOURCE_H_INCLUDE_GUARD
 #define RESOURCE_H_INCLUDE_GUARD
 
+#define RES_FLAG_CHANGING_CONFIG    0x80000000  ///< Administrative config update in progress.
+#define RES_FLAG_RELEVANT           0x40000000  ///< Resource is relevant to current operation.
 
 // Forward declaration needed by res_Resource_t.entryRef.  See resTree.h
 typedef struct resTree_Entry* resTree_EntryRef_t;
@@ -39,7 +41,7 @@ typedef struct res_Resource
     io_DataType_t overrideType;///< Data type of the override, if overrideRef != NULL.
     dataSample_Ref_t defaultValue; ///< Ref to default value; NULL if no default set.
     io_DataType_t defaultType;///< Data type of the default value, if defaultRef != NULL.
-    bool isConfigChanging;  ///< true if filter or routing is being changed.
+    uint32_t flags;  ///< Resource status flags.
     le_dls_List_t pushHandlerList;  ///< List of Push Handler callbacks registered on this resource.
     dataSample_Ref_t jsonExample; ///< Ref to JSON example value; NULL if not set.
 }
@@ -703,6 +705,28 @@ void res_RemoveOverride
     res_Resource_t* resPtr
 );
 
+//--------------------------------------------------------------------------------------------------
+/**
+ * Set the resource's relevance flag.
+ */
+//--------------------------------------------------------------------------------------------------
+void res_SetRelevance
+(
+    res_Resource_t  *resPtr,    ///< Resource to query.
+    bool             relevant   ///< Relevance of resource to current operation.
+);
+
+//--------------------------------------------------------------------------------------------------
+/**
+ * Get the resource's relevance flag.
+ *
+ * @return Relevance of resource to the current operation.
+ */
+//--------------------------------------------------------------------------------------------------
+bool res_IsRelevant
+(
+    res_Resource_t *resPtr ///< Resource to query.
+);
 
 //--------------------------------------------------------------------------------------------------
 /**

--- a/components/dataHub/resource.h
+++ b/components/dataHub/resource.h
@@ -15,6 +15,10 @@
 #define RES_FLAG_NEW                0x20000000  ///< Node has been created since the last snapshot.
 #define RES_FLAG_DELETED            0x10000000  ///< Node has been deleted since deletions were last
                                                 ///< flushed.
+#define RES_FLAG_CLEAR_NEW          0x08000000  ///< Node with new flag set has been used in current
+                                                ///< snapshot, clear its new flag at the end of it.
+#define RES_FLAG_JSON_EX_CHANGED    0x04000000  ///< Node JSON example value has been changed since
+                                                ///< the last snapshot (only for JSON resources).
 
 // Forward declaration needed by res_Resource_t.entryRef.  See resTree.h
 typedef struct resTree_Entry* resTree_EntryRef_t;
@@ -733,6 +737,28 @@ bool res_IsRelevant
 
 //--------------------------------------------------------------------------------------------------
 /**
+ * Set the resource's clear newness flag
+ */
+//--------------------------------------------------------------------------------------------------
+void res_SetClearNewnessFlag
+(
+    res_Resource_t  *resPtr ///< Resource to query.
+);
+
+//--------------------------------------------------------------------------------------------------
+/**
+ * Get the resource's "clear newness" flag.
+ *
+ * @return Whether the resource "newness" flag must be cleared at the end of current snapshot
+ */
+//--------------------------------------------------------------------------------------------------
+bool res_IsNewnessClearRequired
+(
+    res_Resource_t  *resPtr ///< Resource to query.
+);
+
+//--------------------------------------------------------------------------------------------------
+/**
  * Mark a resource as no longer "new."  "New" resources are those that were created after the last
  * snapshot scan of the tree.
  */
@@ -819,6 +845,30 @@ dataSample_Ref_t res_FindBufferedSampleAfter
     double startAfter   ///< Start after this many seconds ago, or after an absolute number of
                         ///< seconds since the Epoch (if startafter > 30 years).
                         ///< Use NAN (not a number) to find the oldest.
+);
+
+
+//--------------------------------------------------------------------------------------------------
+/**
+ * Get the resource's "JSON example changed" flag.
+ *
+ * @return whether the resource's JSON example was updated after the last scan.
+ */
+//--------------------------------------------------------------------------------------------------
+bool res_IsJsonExampleChanged
+(
+    res_Resource_t* resPtr
+);
+
+
+//--------------------------------------------------------------------------------------------------
+/**
+ * Mark a resource's JSON example as not changed.
+ */
+//--------------------------------------------------------------------------------------------------
+void res_ClearJsonExampleChanged
+(
+    res_Resource_t *resPtr ///< Resource to update.
 );
 
 

--- a/components/dataHub/snapshot.c
+++ b/components/dataHub/snapshot.c
@@ -1,0 +1,668 @@
+//--------------------------------------------------------------------------------------------------
+/**
+ * Implementation of the snapshot portion of the Query API.
+ *
+ * Copyright (C) Sierra Wireless Inc.
+ */
+//--------------------------------------------------------------------------------------------------
+#include "snapshot.h"
+
+#include "interfaces.h"
+
+#include "dataHub.h"
+
+/// FIFO path for formatted data streaming.
+#define SNAPSHOT_FIFO   "/tmp/datahub_snapshot_fifo"
+
+/// Default depth of resource tree entries.  This can be overridden in the .cdef.
+#define DEFAULT_NODE_PARENT_POOL_SIZE 10
+
+/// States of the snapshot state machine.
+typedef enum
+{
+    STATE_NODE_BEGIN = 0,   ///< Begin processing a new tree node.
+    STATE_NODE_CHILDREN,    ///< Begin processing children of a tree node.
+    STATE_NODE_END,         ///< Finish processing the current tree node.
+    STATE_NODE_SIBLING,     ///< Begin processing the next sibling of a tree node.
+    STATE_TREE_END,         ///< Done processing all tree nodes.
+    STATE_MAX               ///< One larger than highest state value.
+} SnapshotState_t;
+
+/// Active snapshot state structure.
+typedef struct
+{
+    int sink;   ///< FIFO handle to write formatted snapshot to.
+    int source; ///< FIFO handle to read formatted snapshot from (passed to remote side).
+
+    uint32_t                 flags;     ///< Snapshot flags.
+    double                   since;     ///< Only include updates newer than this time stamp.
+    snapshot_Formatter_t    *formatter; ///< Formatter to use to write snapshot data.
+    double                   timestamp; ///< When the snapshot operation was started.
+
+    query_HandleSnapshotResultFunc_t     callback;  ///< Callback to invoke to indicate end of
+                                                    ///< snapshot, or error.
+    void                                *context;   ///< User context for result callback.
+
+    SnapshotState_t          nextState; ///< Next snapshot processing state to transition to.
+    resTree_EntryRef_t       nodeRef;   ///< Active resource tree node.
+} Snapshot_t;
+
+/// Node parent stack entry.
+typedef struct
+{
+    le_sls_Link_t       link;       ///< Link to next list entry.
+    resTree_EntryRef_t  nodeRef;    ///< Stacked parent node.
+} Parent_t;
+
+/// Keep track of deleted resources?
+static bool AreDeletionsTracked;
+
+/// Is a snapshot request currently in progress?
+static bool IsRunning;
+
+/// Active snapshot state.
+static Snapshot_t Snapshot;
+
+/// Pool of node parent references.
+static le_mem_PoolRef_t NodeParentPool = NULL;
+LE_MEM_DEFINE_STATIC_POOL(NodeParentPool, DEFAULT_NODE_PARENT_POOL_SIZE, sizeof(Parent_t));
+
+/// Stack of node parent references.
+static le_sls_List_t Parents = LE_SLS_LIST_DECL_INIT;
+
+//--------------------------------------------------------------------------------------------------
+/*
+ *  Obtain the flags for the current snapshot operation.
+ *
+ *  @return Flags for the current snapshot.
+ */
+//--------------------------------------------------------------------------------------------------
+uint32_t snapshot_GetFlags
+(
+    void
+)
+{
+    LE_ASSERT(IsRunning);
+    return Snapshot.flags;
+}
+
+//--------------------------------------------------------------------------------------------------
+/*
+ *  Obtain the file stream to write formatted output to for the current snapshot operation.
+ *
+ *  @return File descriptor for the formatted output stream.
+ */
+//--------------------------------------------------------------------------------------------------
+int snapshot_GetStream
+(
+    void
+)
+{
+    LE_ASSERT(IsRunning);
+    return Snapshot.sink;
+}
+
+//--------------------------------------------------------------------------------------------------
+/*
+ *  Obtain the resource tree node currently under consideration.
+ *
+ *  @return Node reference.
+ */
+//--------------------------------------------------------------------------------------------------
+resTree_EntryRef_t snapshot_GetNode
+(
+    void
+)
+{
+    LE_ASSERT(IsRunning);
+    LE_ASSERT(Snapshot.nodeRef != NULL);
+    return Snapshot.nodeRef;
+}
+
+//--------------------------------------------------------------------------------------------------
+/*
+ *  Obtain the time stamp of the start of the snapshot operation.
+ *
+ *  @return File descriptor for the formatted output stream.
+ */
+//--------------------------------------------------------------------------------------------------
+double snapshot_GetTimestamp
+(
+    void
+)
+{
+    LE_ASSERT(IsRunning);
+    return Snapshot.timestamp;
+}
+
+//--------------------------------------------------------------------------------------------------
+/*
+ * Determine if the given node is within the time window of interest for the current snapshot
+ * operation.
+ */
+//--------------------------------------------------------------------------------------------------
+bool snapshot_IsTimely
+(
+    resTree_EntryRef_t nodeRef ///< Node reference.
+)
+{
+    LE_ASSERT(IsRunning);
+    return (resTree_GetLastModified(nodeRef) > Snapshot.since);
+}
+
+//--------------------------------------------------------------------------------------------------
+/*
+ *  Push a parent node reference onto the stack as we descend to a child.
+ */
+//--------------------------------------------------------------------------------------------------
+static void PushParent
+(
+    resTree_EntryRef_t parentRef    ///< New parent to push onto the stack.
+)
+{
+    Parent_t *entry = le_mem_Alloc(NodeParentPool);
+    entry->link = LE_SLS_LINK_INIT;
+    entry->nodeRef = parentRef;
+
+    le_sls_Stack(&Parents, &entry->link);
+}
+
+//--------------------------------------------------------------------------------------------------
+/*
+ *  Pop a parent node reference off the stack as we back out of a child node.
+ *
+ *  @return The parent node reference, or NULL if no entries were present on the stack.
+ */
+//--------------------------------------------------------------------------------------------------
+static resTree_EntryRef_t PopParent
+(
+    void
+)
+{
+    le_sls_Link_t       *link = le_sls_Pop(&Parents);
+    Parent_t            *entry;
+    resTree_EntryRef_t   parentRef = NULL;
+
+    if (link != NULL)
+    {
+        entry = CONTAINER_OF(link, Parent_t, link);
+        parentRef = entry->nodeRef;
+        le_mem_Release(entry);
+    }
+    return parentRef;
+}
+
+//--------------------------------------------------------------------------------------------------
+/*
+ * Begin processing a resource tree node.  This will cumulatively perform a depth-first traversal of
+ * the tree from the current node and invoke the formatter as it goes.
+ */
+//--------------------------------------------------------------------------------------------------
+static void NodeBegin
+(
+    void *unused1,  ///< [IN] Unused parameter.
+    void *unused2   ///< [IN] Unused parameter.
+)
+{
+    resTree_EntryRef_t childRef;
+
+    LE_UNUSED(unused1);
+    LE_UNUSED(unused2);
+
+    LE_DEBUG("Handling node beginning");
+
+    if (Snapshot.since == QUERY_BEGINNING_OF_TIME || resTree_IsRelevant(Snapshot.nodeRef))
+    {
+        childRef = resTree_GetFirstChild(Snapshot.nodeRef);
+        Snapshot.nextState = (childRef == NULL ? STATE_NODE_END : STATE_NODE_CHILDREN);
+        Snapshot.formatter->beginNode(Snapshot.formatter);
+    }
+    else
+    {
+        Snapshot.nextState = STATE_NODE_END;
+        snapshot_Step();
+    }
+}
+
+//--------------------------------------------------------------------------------------------------
+/*
+ * Begin processing the children of a tree node.
+ */
+//--------------------------------------------------------------------------------------------------
+static void NodeChildren
+(
+    void *unused1,  ///< [IN] Unused parameter.
+    void *unused2   ///< [IN] Unused parameter.
+)
+{
+    LE_UNUSED(unused1);
+    LE_UNUSED(unused2);
+
+    LE_DEBUG("Handling node children");
+
+    PushParent(Snapshot.nodeRef);
+    Snapshot.nodeRef = resTree_GetFirstChild(Snapshot.nodeRef);
+
+    // We should only get here if we already checked for children.
+    LE_ASSERT(Snapshot.nodeRef != NULL);
+
+    // No additional formatting here, so directly transition the state machine.
+    Snapshot.nextState = STATE_NODE_BEGIN;
+    snapshot_Step();
+}
+
+//--------------------------------------------------------------------------------------------------
+/*
+ * End processing a tree node.
+ */
+//--------------------------------------------------------------------------------------------------
+static void NodeEnd
+(
+    void *unused1,  ///< [IN] Unused parameter.
+    void *unused2   ///< [IN] Unused parameter.
+)
+{
+    LE_UNUSED(unused1);
+    LE_UNUSED(unused2);
+
+    LE_DEBUG("Handling node end");
+
+    Snapshot.nextState = STATE_NODE_SIBLING;
+    if (Snapshot.since == QUERY_BEGINNING_OF_TIME || resTree_IsRelevant(Snapshot.nodeRef))
+    {
+        Snapshot.formatter->endNode(Snapshot.formatter);
+    }
+    else
+    {
+        snapshot_Step();
+    }
+}
+
+//--------------------------------------------------------------------------------------------------
+/*
+ * Move to the next sibling of the current tree node.
+ */
+//--------------------------------------------------------------------------------------------------
+static void NodeSibling
+(
+    void *unused1,  ///< [IN] Unused parameter.
+    void *unused2   ///< [IN] Unused parameter.
+)
+{
+    resTree_EntryRef_t nodeRef = Snapshot.nodeRef;
+
+    LE_UNUSED(unused1);
+    LE_UNUSED(unused2);
+
+    LE_DEBUG("Handling node sibling");
+
+    Snapshot.nodeRef = resTree_GetNextSibling(nodeRef);
+    if (Snapshot.nodeRef == NULL)
+    {
+        // No more siblings, try looking for a parent.
+        Snapshot.nodeRef = PopParent();
+        if (Snapshot.nodeRef == NULL)
+        {
+            // No more parents, we are done.
+            Snapshot.nextState = STATE_TREE_END;
+            Snapshot.formatter->endTree(Snapshot.formatter);
+            return;
+        }
+        else
+        {
+            // We have a parent, so back out to its level.
+            Snapshot.nextState = STATE_NODE_END;
+        }
+    }
+    else
+    {
+        // There is another sibling, move to it.
+        Snapshot.nextState = STATE_NODE_BEGIN;
+    }
+
+    // No formatting to do, so directly transition to the next state.
+    snapshot_Step();
+}
+
+//--------------------------------------------------------------------------------------------------
+/*
+ * End the snapshot state machine.
+ */
+//--------------------------------------------------------------------------------------------------
+static void TreeEnd
+(
+    void *unused1,  ///< [IN] Unused parameter.
+    void *unused2   ///< [IN] Unused parameter.
+)
+{
+    LE_UNUSED(unused1);
+    LE_UNUSED(unused2);
+
+    LE_DEBUG("Handling tree end");
+
+    // Should never get here with a parent still on the stack.
+    LE_ASSERT(PopParent() == NULL);
+
+    snapshot_End(LE_OK);
+}
+
+//--------------------------------------------------------------------------------------------------
+/*
+ * Transition the tree-walking snapshot state machine to the next state.
+ */
+//--------------------------------------------------------------------------------------------------
+void snapshot_Step
+(
+    void
+)
+{
+    const le_event_DeferredFunc_t steps[STATE_MAX] =
+    {
+        &NodeBegin,     // STATE_NODE_BEGIN
+        &NodeChildren,  // STATE_NODE_CHILDREN
+        &NodeEnd,       // STATE_NODE_END
+        &NodeSibling,   // STATE_NODE_SIBLING
+        &TreeEnd        // STATE_TREE_END
+    };
+#if LE_DEBUG_ENABLED
+    const char *stepNames[STATE_MAX] =
+    {
+        "STATE_NODE_BEGIN",
+        "STATE_NODE_CHILDREN",
+        "STATE_NODE_END",
+        "STATE_NODE_SIBLING",
+        "STATE_TREE_END"
+    };
+#endif /* end LE_DEBUG_ENABLED */
+
+    LE_ASSERT(Snapshot.nextState >= STATE_NODE_BEGIN && Snapshot.nextState < STATE_MAX);
+    LE_DEBUG("Snapshot transition: -> %s", stepNames[Snapshot.nextState]);
+    le_event_QueueFunction(steps[Snapshot.nextState], NULL, NULL);
+}
+
+//--------------------------------------------------------------------------------------------------
+/*
+ * Invoke the result callback to provide final snapshot job status to the user.
+ */
+//--------------------------------------------------------------------------------------------------
+static void InvokeResultCallback
+(
+    void    *status,    ///< [IN] User result callback.
+    void    *unused     ///< [IN] Unused parameter.
+)
+{
+    LE_UNUSED(unused);
+
+    LE_DEBUG("Invoking result callback");
+    if (Snapshot.callback != NULL)
+    {
+        Snapshot.callback((le_result_t) status, Snapshot.context);
+    }
+}
+
+//--------------------------------------------------------------------------------------------------
+/*
+ * Remove all existing deletion records.
+ */
+//--------------------------------------------------------------------------------------------------
+static void FlushDeletionRecords
+(
+    void
+)
+{
+    // TODO: something useful
+}
+
+//--------------------------------------------------------------------------------------------------
+/*
+ * End snapshot and tidy up state.
+ *
+ * Close the formatter and file handles, and queue up the result callback to provide the status to
+ * the user.
+ */
+//--------------------------------------------------------------------------------------------------
+void snapshot_End
+(
+    le_result_t status  ///< [IN] Result of the snapshot request.
+)
+{
+    LE_DEBUG("Ending snapshot with status %s", LE_RESULT_TXT(status));
+
+    if (Snapshot.formatter != NULL)
+    {
+        Snapshot.formatter->close(Snapshot.formatter);
+        Snapshot.formatter = NULL;
+    }
+    if (Snapshot.sink >= 0)
+    {
+        le_fd_Close(Snapshot.sink);
+    }
+    if (Snapshot.source >= 0)
+    {
+        le_fd_Close(Snapshot.source);
+    }
+
+    if (status == LE_OK && (Snapshot.flags & QUERY_SNAPSHOT_FLAG_FLUSH_DELETIONS))
+    {
+        FlushDeletionRecords();
+    }
+
+    // Resume resource tree updates.
+    resTree_EndUpdate();
+    IsRunning = false;
+
+    le_event_QueueFunction(&InvokeResultCallback, (void *) (uintptr_t) status, NULL);
+}
+
+//--------------------------------------------------------------------------------------------------
+/*
+ * Recursively set the relevance flag for the specified node and its children.
+ */
+//--------------------------------------------------------------------------------------------------
+static void UpdateRelevance
+(
+    resTree_EntryRef_t nodeRef ///< Node reference.
+)
+{
+    bool                relevant;
+    bool                timely = snapshot_IsTimely(nodeRef);
+    resTree_EntryRef_t  childRef = resTree_GetFirstChild(nodeRef);
+
+    relevant = timely;
+
+    // Regardless of this node's timeliness, it is considered relevant if at least one child node is
+    // relevant, in order to provide a "here to there" path.
+    while (childRef != NULL)
+    {
+        UpdateRelevance(childRef);
+        relevant = resTree_IsRelevant(childRef) || relevant;
+        childRef = resTree_GetNextSibling(childRef);
+    }
+    resTree_SetRelevance(nodeRef, relevant);
+
+    // Timeliness implies relevance, but the reverse is not true.  Ensure that this condition is
+    // met.
+    LE_ASSERT(!(timely && !relevant));
+}
+
+//--------------------------------------------------------------------------------------------------
+/*
+ * Initialise the pipe/FIFO for passing back formatted data.
+ */
+//--------------------------------------------------------------------------------------------------
+static inline void InitPipe
+(
+    void
+)
+#if LE_CONFIG_RTOS
+{
+    Snapshot.sink = le_fd_Open(SNAPSHOT_FIFO, O_WRONLY | O_NONBLOCK);
+    Snapshot.source = le_fd_Open(SNAPSHOT_FIFO, O_RDONLY | O_NONBLOCK);
+}
+#else /* not LE_CONFIG_RTOS */
+{
+    int fds[2] = { -1, -1 };
+
+    // We don't bother checking the return value here because the FDs will be checked as soon as we
+    // return.
+    pipe2(fds, O_NONBLOCK);
+    Snapshot.sink = fds[1];
+    Snapshot.source = fds[0];
+}
+#endif /* end not LE_CONFIG_RTOS */
+
+//--------------------------------------------------------------------------------------------------
+/*
+ * Capture a snapshot of the resource tree.
+ *
+ * The snapshot will be of the portion of the tree rooted at the given path, and include all values
+ * which have changed since the provided time stamp.  The response will be encoded according to the
+ * specified formatter and streamed back to the requester via the provided file handle.  The end of
+ * data or an error will be indicated by invoking the provided callback with a result code.
+ *
+ * If deletions are being tracked (@see query_TrackDeletions), then information about deleted
+ * resources will be included in the snapshot if the formatter includes it.  The
+ * SNAPSHOT_FLAG_FLUSH_DELETIONS flag may be passed to flush and reset the current deletion tracking
+ * as part of the snapshot operation.  Doing this would mean that deletion information would only be
+ * available back to the time stamp of the last snapshot.
+ */
+//--------------------------------------------------------------------------------------------------
+void query_TakeSnapshot
+(
+    uint32_t     format,    ///< [IN] Snapshot output data format.
+    uint32_t     flags,     ///< [IN] Flags controlling the snapshot action.
+    const char  *path,      ///< [IN] Tree path to use as the root.
+    double       since,     ///< [IN] Request only values that have changed since this time (in s).
+                            ///<      Use BEGINNING_OF_TIME to request the full tree.
+    query_HandleSnapshotResultFunc_t callback,  ///< [IN]  Completion callback to indicate the end
+                                                ///<       of the streamed snapshot, or an error.
+    void        *contextPtr,    ///< [IN]  User context for the completion callback.
+    int         *snapshotStream ///< [OUT] File descriptor to which the encoded snapshot data will
+                                ///<       be streamed.
+)
+{
+    le_clk_Time_t   currentTime;
+    le_result_t     status = LE_OK;
+
+    LE_ASSERT(callback != NULL);
+    LE_ASSERT(path != NULL);
+    LE_ASSERT(snapshotStream != NULL);
+
+    *snapshotStream = -1;
+    if (IsRunning)
+    {
+        // Already running, so indicate we are busy.
+        status = LE_BUSY;
+        le_event_QueueFunction(&InvokeResultCallback, (void *) (uintptr_t) status, NULL);
+        return;
+    }
+    IsRunning = true;
+
+    // Pause updates to the tree while the snapshot scan runs.
+    resTree_StartUpdate();
+
+    memset(&Snapshot, 0, sizeof(Snapshot));
+    Snapshot.callback = callback;
+    Snapshot.context = contextPtr;
+    InitPipe();
+    if (Snapshot.sink < 0 || Snapshot.source < 0)
+    {
+        status = LE_CLOSED;
+        goto end;
+    }
+
+    // NOTE: In the future it may be possible to plug in more formatters, but for now this is a
+    //       fixed list.
+    switch (format)
+    {
+        // TODO: implement formatters
+        // case QUERY_SNAPSHOT_FORMAT_JSON:
+        //     status = GetJsonSnapshotFormatter(flags, Snapshot.sink, &Snapshot.formatter);
+        //     break;
+        // case QUERY_SNAPSHOT_FORMAT_OCTAVE:
+        //     status = GetOctaveSnapshotFormatter(flags, Snapshot.sink, &Snapshot.formatter);
+        //     break;
+        default:
+            status = LE_NOT_IMPLEMENTED;
+            break;
+    }
+    if (Snapshot.formatter == NULL)
+    {
+        goto end;
+    }
+
+    Snapshot.nodeRef = resTree_FindEntryAtAbsolutePath(path);
+    if (Snapshot.nodeRef == NULL)
+    {
+        status = LE_NOT_FOUND;
+        goto end;
+    }
+
+    Snapshot.flags = flags;
+    Snapshot.since = since;
+    Snapshot.nextState = STATE_NODE_BEGIN;
+    *snapshotStream = Snapshot.source;
+
+    currentTime = le_clk_GetAbsoluteTime();
+    Snapshot.timestamp = (((double) currentTime.usec) / 1000000) + currentTime.sec;
+
+    if (Snapshot.since > QUERY_BEGINNING_OF_TIME)
+    {
+        UpdateRelevance(Snapshot.nodeRef);
+    }
+
+    Snapshot.formatter->startTree(Snapshot.formatter);
+
+end:
+    if (status != LE_OK)
+    {
+        // End the snapshot request and unlock the tree if it is locked.
+        snapshot_End(status);
+    }
+}
+
+//--------------------------------------------------------------------------------------------------
+/*
+ * Control whether deletion records should be maintained within the Data Hub.
+ *
+ * Turning on deletion tracking will cause a small amount of metadata to be retained for each
+ * deleted resource.  This metadata will be supplied to the formatter when a snapshot is requested
+ * so that nodes which have disappeared from the tree can be recorded appropriately.  Because this
+ * metadata will gradually accumulate over time as nodes are removed, there are two ways of
+ * requesting that the deletion data be flushed.  The first is to just disable and then reenable
+ * tracking using this function.  The second is to pass the SNAPSHOT_FLAG_FLUSH_DELETIONS flag when
+ * requesting a snapshot.
+ */
+//--------------------------------------------------------------------------------------------------
+void query_TrackDeletions
+(
+    bool on ///< [IN] If true, start tracking deletions; if false stop tracking and flush records.
+)
+{
+    AreDeletionsTracked = on;
+    if (!AreDeletionsTracked)
+    {
+        FlushDeletionRecords();
+    }
+}
+
+//--------------------------------------------------------------------------------------------------
+/*
+ * Initialise the snapshot system.
+ */
+//--------------------------------------------------------------------------------------------------
+void snapshot_Init
+(
+    void
+)
+{
+#if LE_CONFIG_RTOS
+    LE_ASSERT(le_fd_MkFifo(SNAPSHOT_FIFO, S_IRUSR | S_IWUSR) == 0);
+#endif
+
+    NodeParentPool = le_mem_InitStaticPool(
+                        NodeParentPool,
+                        DEFAULT_NODE_PARENT_POOL_SIZE,
+                        sizeof(Parent_t)
+                    );
+}

--- a/components/dataHub/snapshot.c
+++ b/components/dataHub/snapshot.c
@@ -10,6 +10,7 @@
 #include "interfaces.h"
 
 #include "dataHub.h"
+#include "jsonFormatter.h"
 
 /// FIFO path for formatted data streaming.
 #define SNAPSHOT_FIFO   "/tmp/datahub_snapshot_fifo"
@@ -575,10 +576,9 @@ void query_TakeSnapshot
     //       fixed list.
     switch (format)
     {
-        // TODO: implement formatters
-        // case QUERY_SNAPSHOT_FORMAT_JSON:
-        //     status = GetJsonSnapshotFormatter(flags, Snapshot.sink, &Snapshot.formatter);
-        //     break;
+        case QUERY_SNAPSHOT_FORMAT_JSON:
+            status = GetJsonSnapshotFormatter(flags, Snapshot.sink, &Snapshot.formatter);
+            break;
         // case QUERY_SNAPSHOT_FORMAT_OCTAVE:
         //     status = GetOctaveSnapshotFormatter(flags, Snapshot.sink, &Snapshot.formatter);
         //     break;

--- a/components/dataHub/snapshot.h
+++ b/components/dataHub/snapshot.h
@@ -1,0 +1,144 @@
+//--------------------------------------------------------------------------------------------------
+/**
+ * @file snapshot.h
+ *
+ * Internal interface of the snapshot portion of the Query API.  This interface defines the API for
+ * snapshot formatters and the hooks for deletion tracking.
+ *
+ * Copyright (C) Sierra Wireless Inc.
+ */
+//--------------------------------------------------------------------------------------------------
+
+#ifndef SNAPSHOT_H_INCLUDE_GUARD
+#define SNAPSHOT_H_INCLUDE_GUARD
+
+#include "legato.h"
+
+// Forward reference.
+struct snapshot_Formatter;
+
+//--------------------------------------------------------------------------------------------------
+/**
+ * Reference to a Resource Tree Entry.
+ */
+//--------------------------------------------------------------------------------------------------
+typedef struct resTree_Entry *resTree_EntryRef_t;
+
+//--------------------------------------------------------------------------------------------------
+/*
+ * Callback to trigger an action by the formatter plugin.
+ */
+//--------------------------------------------------------------------------------------------------
+typedef void (*formatter_Callback_t)
+(
+    struct snapshot_Formatter *formatter ///< Formatter instance.
+);
+
+//--------------------------------------------------------------------------------------------------
+/*
+ * Base type for a resource tree snapshot formatter.
+ */
+//--------------------------------------------------------------------------------------------------
+typedef struct snapshot_Formatter
+{
+    formatter_Callback_t startTree; ///< Callback to format the beginning of the resource tree.
+    formatter_Callback_t beginNode; ///< Callback to format the beginning of a new tree node.
+    formatter_Callback_t endNode;   ///< Callback to format the end of an open tree node.
+    formatter_Callback_t endTree;   ///< Callback to format the end of all tree nodes.
+    formatter_Callback_t close;     ///< Callback to close and clean up the formatter instance.
+} snapshot_Formatter_t;
+
+//--------------------------------------------------------------------------------------------------
+/*
+ * Initialise the snapshot system.
+ */
+//--------------------------------------------------------------------------------------------------
+void snapshot_Init
+(
+    void
+);
+
+//--------------------------------------------------------------------------------------------------
+/*
+ *  Obtain the flags for the current snapshot operation.
+ *
+ *  @return Flags for the current snapshot.
+ */
+//--------------------------------------------------------------------------------------------------
+LE_SHARED uint32_t snapshot_GetFlags
+(
+    void
+);
+
+//--------------------------------------------------------------------------------------------------
+/*
+ *  Obtain the file stream to write formatted output to for the current snapshot operation.
+ *
+ *  @return File descriptor for the formatted output stream.
+ */
+//--------------------------------------------------------------------------------------------------
+LE_SHARED int snapshot_GetStream
+(
+    void
+);
+
+//--------------------------------------------------------------------------------------------------
+/*
+ *  Obtain the resource tree node currently under consideration.
+ *
+ *  @return Node reference.
+ */
+//--------------------------------------------------------------------------------------------------
+LE_SHARED resTree_EntryRef_t snapshot_GetNode
+(
+    void
+);
+
+//--------------------------------------------------------------------------------------------------
+/*
+ *  Obtain the time at which the snapshot was initiated.
+ *
+ *  @return Snapshot time stamp.
+ */
+//--------------------------------------------------------------------------------------------------
+LE_SHARED double snapshot_GetTimestamp
+(
+    void
+);
+
+//--------------------------------------------------------------------------------------------------
+/*
+ * Determine if the given node is within the time window of interest for the current snapshot
+ * operation.
+ */
+//--------------------------------------------------------------------------------------------------
+LE_SHARED bool snapshot_IsTimely
+(
+    resTree_EntryRef_t nodeRef ///< Node reference.
+);
+
+//--------------------------------------------------------------------------------------------------
+/*
+ * Transition the tree-walking snapshot state machine to the next state.
+ */
+//--------------------------------------------------------------------------------------------------
+LE_SHARED void snapshot_Step
+(
+    void
+);
+
+//--------------------------------------------------------------------------------------------------
+/*
+ * End snapshot and tidy up state.
+ *
+ * Close the formatter and file handles, and queue up the result callback to provide the status to
+ * the user.  May be invoked from a formatter in exceptional circumstances to return early or return
+ * an error.
+ */
+//--------------------------------------------------------------------------------------------------
+LE_SHARED void snapshot_End
+(
+    le_result_t status  ///< [IN] Result of the snapshot request.
+);
+
+#endif /* end SNAPSHOT_H_INCLUDE_GUARD */

--- a/components/dataHub/snapshot.h
+++ b/components/dataHub/snapshot.h
@@ -14,6 +14,13 @@
 
 #include "legato.h"
 
+/// Filter for newly created nodes.
+#define SNAPSHOT_FILTER_CREATED 0x1
+/// Filter for deleted nodes.
+#define SNAPSHOT_FILTER_DELETED 0x2
+/// Filter for normal nodes (i.e. not new or deleted).
+#define SNAPSHOT_FILTER_NORMAL  0x4
+
 // Forward reference.
 struct snapshot_Formatter;
 
@@ -46,6 +53,9 @@ typedef struct snapshot_Formatter
     formatter_Callback_t endNode;   ///< Callback to format the end of an open tree node.
     formatter_Callback_t endTree;   ///< Callback to format the end of all tree nodes.
     formatter_Callback_t close;     ///< Callback to close and clean up the formatter instance.
+
+    bool        scan;   ///< Request a scan of the resource tree.
+    uint32_t    filter; ///< Mask to filter nodes during tree traversal.
 } snapshot_Formatter_t;
 
 //--------------------------------------------------------------------------------------------------
@@ -56,6 +66,16 @@ typedef struct snapshot_Formatter
 void snapshot_Init
 (
     void
+);
+
+//--------------------------------------------------------------------------------------------------
+/*
+ *  Record the deletion of a node so that it can be included with a snapshot.
+ */
+//--------------------------------------------------------------------------------------------------
+void snapshot_RecordNodeDeletion
+(
+    resTree_EntryRef_t nodeRef  ///< Deleted node.
 );
 
 //--------------------------------------------------------------------------------------------------

--- a/components/dataHub/snapshot.h
+++ b/components/dataHub/snapshot.h
@@ -116,6 +116,18 @@ LE_SHARED resTree_EntryRef_t snapshot_GetNode
 
 //--------------------------------------------------------------------------------------------------
 /*
+ *  Obtain the resource tree node used as root for snapshot.
+ *
+ *  @return Node reference.
+ */
+//--------------------------------------------------------------------------------------------------
+LE_SHARED resTree_EntryRef_t snapshot_GetRoot
+(
+    void
+);
+
+//--------------------------------------------------------------------------------------------------
+/*
  *  Obtain the time at which the snapshot was initiated.
  *
  *  @return Snapshot time stamp.

--- a/components/json/Component.cdef
+++ b/components/json/Component.cdef
@@ -1,7 +1,6 @@
 //--------------------------------------------------------------------------------------------------
 /**
- * Periodic sensor component. Simplifies the implementation of a periodic sensor that is connected
- * to and controlled by the Data Hub.
+ * JSON String Parser API.
  *
  * Copyright (C) Sierra Wireless Inc.
  */

--- a/components/jsonFormatter/Component.cdef
+++ b/components/jsonFormatter/Component.cdef
@@ -1,0 +1,28 @@
+//--------------------------------------------------------------------------------------------------
+/**
+ * Snapshot formatter producing JSON output.
+ *
+ * Copyright (C) Sierra Wireless Inc.
+ */
+//--------------------------------------------------------------------------------------------------
+
+requires:
+{
+    api:
+    {
+        admin.api   [types-only]
+        io.api      [types-only]
+        query.api   [types-only]
+    }
+}
+
+cflags:
+{
+    -std=c99
+    -I$CURDIR/../dataHub
+}
+
+sources:
+{
+    jsonFormatter.c
+}

--- a/components/jsonFormatter/jsonFormatter.c
+++ b/components/jsonFormatter/jsonFormatter.c
@@ -1,0 +1,687 @@
+//--------------------------------------------------------------------------------------------------
+/**
+ * Snapshot formatter producing JSON output.
+ *
+ * Copyright (C) Sierra Wireless Inc.
+ */
+//--------------------------------------------------------------------------------------------------
+#include "jsonFormatter.h"
+
+#include "interfaces.h"
+
+#include "dataHub.h"
+#include "snapshot.h"
+
+/// Internal formatter states.
+typedef enum
+{
+    STATE_START = 0,        ///< Beginning of the document.
+    STATE_SNAPSHOT_STEP,    ///< Trigger next outer state machine step.
+    STATE_NODE_NAME,        ///< Output node name.
+    STATE_NODE_OPEN,        ///< Output node opening.
+    STATE_NODE_VALUES,      ///< Output node data fields.
+    STATE_NODE_VALUE_BODY,  ///< Output node value.
+    STATE_MAX               ///< One larger than highest state value.
+} JsonFormatterState_t;
+
+/// JSON formatter state.
+typedef struct JsonFormatter
+{
+    snapshot_Formatter_t    base;       ///< Base type containing tree handling callbacks.
+    char                    buffer[HUB_MAX_STRING_BYTES + 2];   ///< Buffer for preparing formatted
+                                                                ///< output.  Two extra bytes for
+                                                                ///< potential quotation marks.
+    size_t                  next;       ///< Offset of the next character to send.
+    size_t                  available;  ///< Number of bytes available to be sent.
+    bool                    needsComma; ///< Does the next item output need to prepend a comma?
+    bool                    isRoot;     ///< Is the next node output the root node?
+    JsonFormatterState_t    nextState;  ///< Next state to transition to once currently buffered
+                                        ///< data is sent.
+    le_fdMonitor_Ref_t      monitor;    ///< FD monitor for output stream.
+} JsonFormatter_t;
+
+//--------------------------------------------------------------------------------------------------
+/*
+ * Callback for an internal formatter state machine step.
+ */
+//--------------------------------------------------------------------------------------------------
+typedef void (*JsonFormatterStep_t)
+(
+    JsonFormatter_t *jsonFormatter ///< Formatter instance.
+);
+
+// Forward reference.
+static void Step(JsonFormatter_t *jsonFormatter);
+
+//--------------------------------------------------------------------------------------------------
+/*
+ * Send some data from the buffer to the output stream.
+ *
+ * @return -1 on error, 0 if all data was sent, or 1 if more data remains to be sent.
+ */
+//--------------------------------------------------------------------------------------------------
+static int SendData
+(
+    JsonFormatter_t *jsonFormatter, ///< Formatter instance.
+    int              stream         ///< Output stream FD.
+)
+{
+    const char  *start = &jsonFormatter->buffer[jsonFormatter->next];
+    ssize_t      count;
+
+    if (jsonFormatter->available == 0)
+    {
+        LE_DEBUG("Nothing to send");
+        return 1;
+    }
+
+    count = le_fd_Write(stream, start, jsonFormatter->available);
+    if (count < 0)
+    {
+        // An error occurred.
+        return -1;
+    }
+    else if (count < (ssize_t) jsonFormatter->available)
+    {
+        LE_DEBUG("Sent some (%d bytes): %*s", (int) count, (int) count, start);
+
+        // Didn't send all of the available data.
+        jsonFormatter->next += count;
+        jsonFormatter->available -= count;
+        LE_ASSERT(jsonFormatter->next < sizeof(jsonFormatter->buffer));
+        return 1;
+    }
+    else
+    {
+        LE_ASSERT(count == (ssize_t) jsonFormatter->available);
+        LE_DEBUG("Sent all (%d bytes): %*s", (int) count, (int) count, start);
+
+        // We've sent everything in the buffer.
+        jsonFormatter->next = 0;
+        jsonFormatter->available = 0;
+        le_fdMonitor_Disable(jsonFormatter->monitor, POLLOUT);
+        return 0;
+    }
+}
+
+//--------------------------------------------------------------------------------------------------
+/*
+ * Handle an FD or manually triggered event on the formatted output stream.
+ */
+//--------------------------------------------------------------------------------------------------
+static void HandleEvents
+(
+    JsonFormatter_t *jsonFormatter, ///< Formatter instance.
+    int              fd,            ///< Output stream file descriptor.
+    short            events         ///< FD event bitfield.
+)
+{
+    int status;
+
+    LE_DEBUG("Handling events 0x%04X", events);
+    if (events & POLLOUT)
+    {
+        // Can send more data, so do it.
+        status = SendData(jsonFormatter, fd);
+        if (status < 0)
+        {
+            // Error sending data, so abort the snapshot.
+            snapshot_End(LE_CLOSED);
+            return;
+        }
+        else if (status == 0)
+        {
+            // Sent all the available data, take action to get more.
+            Step(jsonFormatter);
+            return;
+        }
+
+        // If we got here there is still more data to send from the buffer, so we will just wait
+        // until the next POLLOUT.
+    }
+
+    if (events & POLLHUP)
+    {
+        // Stream was closed for some reason, nothing we can do except terminate the snapshot.
+        snapshot_End(LE_CLOSED);
+    }
+    else if (events & ~POLLOUT)
+    {
+        // Any other condition is an error, so terminate the snapshot.
+        snapshot_End(LE_FAULT);
+    }
+}
+
+//--------------------------------------------------------------------------------------------------
+/*
+ * Handle an event on the formatted output stream.
+ */
+//--------------------------------------------------------------------------------------------------
+static void StreamHandler
+(
+    int     fd,     ///< Output stream file descriptor.
+    short   events  ///< Event bitmask.
+)
+{
+    JsonFormatter_t *jsonFormatter = le_fdMonitor_GetContextPtr();
+
+    LE_DEBUG("Stream event");
+    HandleEvents(jsonFormatter, fd, events);
+}
+
+//--------------------------------------------------------------------------------------------------
+/*
+ * Handle an explicitly triggered event to write to the formatted output stream.
+ */
+//--------------------------------------------------------------------------------------------------
+static void ExplicitSendHandler
+(
+    JsonFormatter_t *jsonFormatter, ///< Formatter instance.
+    void            *unused         ///< Unused.
+)
+{
+    int fd = le_fdMonitor_GetFd(jsonFormatter->monitor);
+
+    LE_UNUSED(unused);
+
+    LE_DEBUG("Explicit send");
+    HandleEvents(jsonFormatter, fd, POLLOUT);
+}
+
+//--------------------------------------------------------------------------------------------------
+/*
+ * (Re)enable events on formatted output stream.
+ */
+//--------------------------------------------------------------------------------------------------
+static void EnableSend
+(
+    JsonFormatter_t *jsonFormatter ///< Formatter instance.
+)
+{
+    le_fdMonitor_Enable(jsonFormatter->monitor, POLLOUT);
+
+    // Explicitly trigger an attempt to send, since the stream might be sitting ready and therefore
+    // not generate a new POLLOUT.
+    le_event_QueueFunction((le_event_DeferredFunc_t) &ExplicitSendHandler, jsonFormatter, NULL);
+}
+
+//--------------------------------------------------------------------------------------------------
+/*
+ * Append a string to the current contents of the output buffer.
+ */
+//--------------------------------------------------------------------------------------------------
+static void AppendString
+(
+    JsonFormatter_t *jsonFormatter, ///< Formatter instance.
+    bool             prependComma,  ///< Prepend a comma to the value being added?
+    const char      *str            ///< String to append to the buffer.  It is expected that this
+                                    ///< is sized so as to avoid overflowing the buffer.
+)
+{
+    // We should never be handed a combined string larger than the Data Hub's maximum string
+    // size + 2, so an overflow should not occur and we can assert if it does.
+    if (prependComma)
+    {
+        LE_ASSERT_OK(
+            le_utf8_Append(jsonFormatter->buffer, ",", sizeof(jsonFormatter->buffer), NULL)
+        );
+    }
+    LE_ASSERT_OK(le_utf8_Append(jsonFormatter->buffer, str, sizeof(jsonFormatter->buffer), NULL));
+
+    jsonFormatter->available = strlen(jsonFormatter->buffer);
+    EnableSend(jsonFormatter);
+}
+
+//--------------------------------------------------------------------------------------------------
+/*
+ * Write a string to the the output buffer.
+ */
+//--------------------------------------------------------------------------------------------------
+static void BufferString
+(
+    JsonFormatter_t *jsonFormatter, ///< Formatter instance.
+    bool             prependComma,  ///< Prepend a comma to the value being added?
+    const char      *str            ///< String to write to the buffer.  It is expected that this
+                                    ///< is sized so as to avoid overflowing the buffer.
+)
+{
+    LE_ASSERT(jsonFormatter->next == 0);
+    LE_ASSERT(jsonFormatter->available == 0);
+
+    jsonFormatter->buffer[0] = '\0';
+    AppendString(jsonFormatter, prependComma, str);
+}
+
+//--------------------------------------------------------------------------------------------------
+/*
+ * Write a formatted string to the the output buffer.  It is expected that all inputs will be sized
+ * so as to avoid overflowing the buffer.
+ */
+//--------------------------------------------------------------------------------------------------
+static void BufferFormatted
+(
+    JsonFormatter_t *jsonFormatter, ///< Formatter instance.
+    bool             prependComma,  ///< Prepend a comma to the value being added?
+    const char      *format,        ///< Format string to use to fill the buffer.
+    ...                             ///< Positional parameters for the format string.
+)
+{
+    int     result;
+    size_t  offset = 0;
+    va_list args;
+
+    LE_ASSERT(jsonFormatter->next == 0);
+    LE_ASSERT(jsonFormatter->available == 0);
+
+    if (prependComma)
+    {
+        jsonFormatter->buffer[0] = ',';
+        ++offset;
+    }
+
+    va_start(args, format);
+    result = vsnprintf(
+        jsonFormatter->buffer + offset,
+        sizeof(jsonFormatter->buffer) - offset,
+        format,
+        args
+    );
+    va_end(args);
+
+    // By design the buffer should always be large enough to accommodate the resulting string, so we
+    // can assert here.
+    LE_ASSERT(0 < result && result <= (int) (sizeof(jsonFormatter->buffer) - offset));
+    jsonFormatter->available = result;
+    EnableSend(jsonFormatter);
+}
+
+//--------------------------------------------------------------------------------------------------
+/*
+ * Get the string representation of a boolean.
+ *
+ * @return String representing the boolean value.
+ */
+//--------------------------------------------------------------------------------------------------
+static inline const char *Bool2Str
+(
+    bool value ///< Boolean value.
+)
+{
+    return (value ? "true" : "false");
+}
+
+//--------------------------------------------------------------------------------------------------
+/*
+ * Begin formatting the overall resource tree.
+ */
+//--------------------------------------------------------------------------------------------------
+static void StartTree
+(
+    snapshot_Formatter_t *formatter ///< Formatter instance.
+)
+{
+    char             path[HUB_MAX_RESOURCE_PATH_BYTES];
+    JsonFormatter_t *jsonFormatter = CONTAINER_OF(formatter, JsonFormatter_t, base);
+
+    LE_DEBUG("Starting tree");
+
+    // Buffer is sized such that it should never overflow, and the referenced nodes must exist.
+    LE_ASSERT(resTree_GetPath(path, sizeof(path), resTree_GetRoot(), snapshot_GetNode()) >= 0);
+
+    BufferFormatted(
+        jsonFormatter,
+        false,
+        "{\"ts\":%lf,\"root\":\"%s\",\"upserted\":",
+        snapshot_GetTimestamp(),
+        path
+    );
+
+    // Now we wait for the buffer to drain and call snapshot_Step() when it is done.
+    jsonFormatter->isRoot = true;
+    jsonFormatter->nextState = STATE_SNAPSHOT_STEP;
+}
+
+//--------------------------------------------------------------------------------------------------
+/*
+ * Begin formatting a resource tree node.
+ */
+//--------------------------------------------------------------------------------------------------
+static void BeginNode
+(
+    snapshot_Formatter_t *formatter ///< Formatter instance.
+)
+{
+    JsonFormatter_t *jsonFormatter = CONTAINER_OF(formatter, JsonFormatter_t, base);
+
+    if (jsonFormatter->isRoot)
+    {
+        // The root node never has additional properties, so move directly to the next step once it
+        // is opened.
+        LE_DEBUG("Starting root node");
+        jsonFormatter->nextState = STATE_NODE_OPEN;
+        jsonFormatter->needsComma = false;
+        Step(jsonFormatter);
+    }
+    else
+    {
+        // This node is a child of another, so open the object key entry and follow up with the node
+        // name.
+        LE_DEBUG("Starting child node");
+        BufferString(jsonFormatter, jsonFormatter->needsComma, "\"");
+        jsonFormatter->isRoot = false;
+        jsonFormatter->nextState = STATE_NODE_NAME;
+    }
+}
+
+//--------------------------------------------------------------------------------------------------
+/*
+ * Write the node name part of the object key to the buffer.
+ */
+//--------------------------------------------------------------------------------------------------
+static void NodeName
+(
+    JsonFormatter_t *jsonFormatter ///< Formatter instance.
+)
+{
+    const char *name = resTree_GetEntryName(snapshot_GetNode());
+
+    LE_DEBUG("Output node name: '%s'", name);
+    BufferString(jsonFormatter, false, name);
+    jsonFormatter->needsComma = false;
+    jsonFormatter->nextState = STATE_NODE_OPEN;
+}
+
+//--------------------------------------------------------------------------------------------------
+/*
+ * Write the node opening preamble to the buffer.
+ */
+//--------------------------------------------------------------------------------------------------
+static void NodeOpen
+(
+    JsonFormatter_t *jsonFormatter ///< Formatter instance.
+)
+{
+    resTree_EntryRef_t  node = snapshot_GetNode();
+    admin_EntryType_t   entryType = resTree_GetEntryType(node);
+
+    LE_DEBUG("Open node contents");
+
+    // Non-root node is preceded by `"<name>` so close that off and open the node object.
+    BufferFormatted(jsonFormatter, false, "%s{", (jsonFormatter->isRoot ? "" : "\":"));
+    jsonFormatter->isRoot = false;
+    jsonFormatter->needsComma = false;
+
+    switch (entryType)
+    {
+        case ADMIN_ENTRY_TYPE_NAMESPACE:
+        case ADMIN_ENTRY_TYPE_PLACEHOLDER:
+            // These node types have no additional fields of their own, so proceed to any children
+            // by stepping the outer state machine.
+            jsonFormatter->nextState = STATE_SNAPSHOT_STEP;
+            break;
+        case ADMIN_ENTRY_TYPE_INPUT:
+        case ADMIN_ENTRY_TYPE_OUTPUT:
+        case ADMIN_ENTRY_TYPE_OBSERVATION:
+            if (snapshot_IsTimely(node))
+            {
+                // These node types have additional fields of their own, so start the sequence of
+                // outputting those.
+                jsonFormatter->nextState = STATE_NODE_VALUES;
+            }
+            else
+            {
+                // Skip any values on this node, as we are just transiting it to get somewhere more
+                // interesting.
+                jsonFormatter->nextState = STATE_SNAPSHOT_STEP;
+            }
+            break;
+        default:
+            LE_FATAL("Unexpected entry type: %d", entryType);
+            break;
+    }
+}
+
+//--------------------------------------------------------------------------------------------------
+/*
+ * Write the various node fields to the buffer.
+ */
+//--------------------------------------------------------------------------------------------------
+static void NodeValues
+(
+    JsonFormatter_t *jsonFormatter ///< Formatter instance.
+)
+{
+    char                buffer[64]; // Sized for stringified boolean or double.
+    resTree_EntryRef_t  node = snapshot_GetNode();
+    dataSample_Ref_t    sample = resTree_GetCurrentValue(node);
+    io_DataType_t       dataType = resTree_GetDataType(node);
+
+
+    LE_DEBUG("Output node values");
+
+    // This function should never be called when the current value is unset.
+    LE_ASSERT(sample != NULL);
+
+    BufferFormatted(
+        jsonFormatter,
+        false,
+        "\"type\":%u,\"ts\":%lf,\"mandatory\":%s",
+        dataType,
+        dataSample_GetTimestamp(sample),
+        Bool2Str(resTree_IsMandatory(node))
+    );
+    jsonFormatter->needsComma = true;
+
+    switch (dataType)
+    {
+        case IO_DATA_TYPE_TRIGGER:
+            jsonFormatter->nextState = STATE_SNAPSHOT_STEP;
+            break;
+
+        case IO_DATA_TYPE_BOOLEAN:
+        case IO_DATA_TYPE_NUMERIC:
+            AppendString(jsonFormatter, true, "\"value\":");
+
+            // Buffer is sized such that this should never fail.
+            LE_ASSERT_OK(dataSample_ConvertToJson(sample, dataType, buffer, sizeof(buffer)));
+            AppendString(jsonFormatter, false, buffer);
+            jsonFormatter->nextState = STATE_SNAPSHOT_STEP;
+            break;
+
+        case IO_DATA_TYPE_STRING:
+        case IO_DATA_TYPE_JSON:
+            AppendString(jsonFormatter, true, "\"value\":");
+            jsonFormatter->needsComma = false;
+            jsonFormatter->nextState = STATE_NODE_VALUE_BODY;
+            break;
+    }
+}
+
+//--------------------------------------------------------------------------------------------------
+/*
+ * Write the node value to the buffer for string and JSON types.
+ */
+//--------------------------------------------------------------------------------------------------
+static void NodeValueBody
+(
+    JsonFormatter_t *jsonFormatter ///< Formatter instance.
+)
+{
+    resTree_EntryRef_t  node = snapshot_GetNode();
+    dataSample_Ref_t    sample = resTree_GetCurrentValue(node);
+    io_DataType_t       dataType = resTree_GetDataType(node);
+
+    LE_DEBUG("Output node value body");
+
+    // Don't check comma flag here because this is the value part of a key/value pair and would
+    // never have a leading comma.
+    LE_ASSERT(!jsonFormatter->needsComma);
+
+    // This function should never be called when the current value is unset.
+    LE_ASSERT(sample != NULL);
+
+    // The string/JSON copied in should never be larger than sizeof(jsonFormatter->buffer), so we
+    // can assert if this overflows.
+    LE_ASSERT_OK(dataSample_ConvertToJson(
+        sample,
+        dataType,
+        jsonFormatter->buffer,
+        sizeof(jsonFormatter->buffer)
+    ));
+
+    jsonFormatter->available = strlen(jsonFormatter->buffer);
+    jsonFormatter->needsComma = true;
+    jsonFormatter->nextState = STATE_SNAPSHOT_STEP;
+    EnableSend(jsonFormatter);
+}
+
+//--------------------------------------------------------------------------------------------------
+/*
+ * Finish formatting an object.
+ */
+//--------------------------------------------------------------------------------------------------
+static void EndObject
+(
+    snapshot_Formatter_t *formatter ///< Formatter instance.
+)
+{
+    JsonFormatter_t *jsonFormatter = CONTAINER_OF(formatter, JsonFormatter_t, base);
+
+    LE_DEBUG("Closing object");
+
+    BufferString(jsonFormatter, false, "}");
+
+    // Now we wait for the buffer to drain and call snapshot_Step() when it is done.
+    jsonFormatter->needsComma = true;
+    jsonFormatter->nextState = STATE_SNAPSHOT_STEP;
+}
+
+//--------------------------------------------------------------------------------------------------
+/*
+ * Close and clean up the formatter instance.
+ */
+//--------------------------------------------------------------------------------------------------
+static void Close
+(
+    snapshot_Formatter_t *formatter ///< Formatter instance.
+)
+{
+    JsonFormatter_t *jsonFormatter = CONTAINER_OF(formatter, JsonFormatter_t, base);
+
+    LE_DEBUG("Closing formatter");
+    le_fdMonitor_Delete(jsonFormatter->monitor);
+}
+
+//--------------------------------------------------------------------------------------------------
+/*
+ * Simple wrapper to step the greater state machine.
+ */
+//--------------------------------------------------------------------------------------------------
+static void SnapshotStep
+(
+    JsonFormatter_t *jsonFormatter ///< Formatter instance.
+)
+{
+    LE_UNUSED(jsonFormatter);
+
+    LE_DEBUG("Stepping snapshot state machine");
+    snapshot_Step();
+}
+
+//--------------------------------------------------------------------------------------------------
+/*
+ * Transition the formatter state machine to the next state.
+ */
+//--------------------------------------------------------------------------------------------------
+static void Step
+(
+    JsonFormatter_t *jsonFormatter ///< Formatter instance.
+)
+{
+    const JsonFormatterStep_t steps[STATE_MAX - 1] =
+    {
+        &SnapshotStep,  // STATE_SNAPSHOT_STEP
+        &NodeName,      // STATE_NODE_NAME
+        &NodeOpen,      // STATE_NODE_OPEN
+        &NodeValues,    // STATE_NODE_VALUES
+        &NodeValueBody  // STATE_NODE_VALUE_BODY
+    };
+#if LE_DEBUG_ENABLED
+    const char *stepNames[STATE_MAX - 1] =
+    {
+        "STATE_SNAPSHOT_STEP",
+        "STATE_NODE_NAME",
+        "STATE_NODE_OPEN",
+        "STATE_NODE_VALUES",
+        "STATE_NODE_VALUE_BODY"
+    };
+#endif /* end LE_DEBUG_ENABLED */
+
+    if (jsonFormatter->nextState == STATE_START)
+    {
+        // If things haven't started yet, just wait until they do.
+        return;
+    }
+
+    LE_ASSERT(jsonFormatter->nextState > STATE_START && jsonFormatter->nextState < STATE_MAX);
+    LE_DEBUG("JSON formatter transition: -> %s", stepNames[jsonFormatter->nextState - 1]);
+    steps[jsonFormatter->nextState - 1](jsonFormatter);
+}
+
+//--------------------------------------------------------------------------------------------------
+/*
+ * Initialise and return the JSON snapshot formatter instance.
+ *
+ * @return LE_OK (the JSON formatter initialisation does not generate any errors).
+ */
+//--------------------------------------------------------------------------------------------------
+le_result_t GetJsonSnapshotFormatter
+(
+    uint32_t                  flags,    ///< [IN]  Flags that were passed to the snapshot request.
+    int                       stream,   ///< [IN]  File descriptor to write formatted output to.
+    snapshot_Formatter_t    **formatter ///< [OUT] Returned formatter instance.
+)
+{
+    static JsonFormatter_t jsonFormatter =
+    {
+        {
+            .startTree  = &StartTree,
+            .beginNode  = &BeginNode,
+            .endNode    = &EndObject,
+            .endTree    = &EndObject,
+            .close      = &Close
+        }
+    };
+
+    LE_UNUSED(flags);
+
+    LE_ASSERT(formatter != NULL);
+    *formatter = &jsonFormatter.base;
+
+    memset(jsonFormatter.buffer, 0, sizeof(jsonFormatter.buffer));
+    jsonFormatter.next          = 0;
+    jsonFormatter.available     = 0;
+    jsonFormatter.needsComma    = false;
+    jsonFormatter.isRoot        = true;
+    jsonFormatter.nextState     = STATE_START;
+
+    LE_DEBUG("JSON formatter transition: -> STATE_START");
+
+    // Configure event handler for outputting formatted data.
+    jsonFormatter.monitor = le_fdMonitor_Create(
+                                "JsonSnapshotStream",
+                                stream,
+                                &StreamHandler,
+                                POLLOUT
+                            );
+    le_fdMonitor_SetContextPtr(jsonFormatter.monitor, &jsonFormatter);
+    le_fdMonitor_Disable(jsonFormatter.monitor, POLLOUT);
+
+    return LE_OK;
+}
+
+/// Component initialisation.
+COMPONENT_INIT
+{
+    // Do nothing.
+}

--- a/components/jsonFormatter/jsonFormatter.h
+++ b/components/jsonFormatter/jsonFormatter.h
@@ -1,0 +1,34 @@
+//--------------------------------------------------------------------------------------------------
+/**
+ * @file jsonFormatter.h
+ *
+ * Plugin interface for JSON snapshot formatter.
+ *
+ * Copyright (C) Sierra Wireless Inc.
+ */
+//--------------------------------------------------------------------------------------------------
+
+#ifndef JSONFORMATTER_H_INCLUDE_GUARD
+#define JSONFORMATTER_H_INCLUDE_GUARD
+
+#include "legato.h"
+
+// Forward reference.
+struct snapshot_Formatter;
+
+//--------------------------------------------------------------------------------------------------
+/*
+ * Initialise and return the JSON snapshot formatter instance.
+ *
+ * @return LE_OK on success, otherwise an appropriate error code.
+ */
+//--------------------------------------------------------------------------------------------------
+LE_SHARED le_result_t GetJsonSnapshotFormatter
+(
+    uint32_t                      flags,    ///< [IN]  Flags that were passed to the snapshot
+                                            ///<       request.
+    int                           stream,   ///< [IN]  File descriptor to write formatted output to.
+    struct snapshot_Formatter   **formatter ///< [OUT] Returned formatter instance.
+);
+
+#endif /* end JSONFORMATTER_H_INCLUDE_GUARD */

--- a/components/octaveFormatter/Component.cdef
+++ b/components/octaveFormatter/Component.cdef
@@ -1,0 +1,64 @@
+//--------------------------------------------------------------------------------------------------
+/**
+ * Snapshot formatter producing Octave CBOR output.
+ *
+ * Copyright (C) Sierra Wireless Inc.
+ */
+//--------------------------------------------------------------------------------------------------
+
+requires:
+{
+    api:
+    {
+        admin.api   [types-only]
+        io.api      [types-only]
+        query.api   [types-only]
+    }
+}
+
+cflags:
+{
+    -std=c99
+
+    //TODO use libcbor legato lib when available
+    -I${OCTAVE_ROOT}/common/cbor
+    -I${OCTAVE_ROOT}/common/cbor
+    -I${OCTAVE_ROOT}/common/cbor/inc
+    -I${OCTAVE_ROOT}/common/cbor/libcbor/src
+    -I${OCTAVE_ROOT}/common/json
+    -I${OCTAVE_ROOT}/common/string
+}
+
+sources:
+{
+    octaveFormatter.c
+
+    //TODO use libcbor legato lib when available
+    ${OCTAVE_ROOT}/common/cbor/libcbor/src/cbor/common.c
+    ${OCTAVE_ROOT}/common/cbor/libcbor/src/cbor/encoding.c
+    ${OCTAVE_ROOT}/common/cbor/libcbor/src/cbor/streaming.c
+    ${OCTAVE_ROOT}/common/cbor/libcbor/src/cbor/internal/encoders.c
+    ${OCTAVE_ROOT}/common/cbor/libcbor/src/cbor/internal/loaders.c
+#if ${LE_CONFIG_RTOS} = y
+#else
+    // compiling these is not required on RTOS but removing them makes linux/FX build fail
+    ${OCTAVE_ROOT}/common/cbor/libcbor/src/cbor.c
+    ${OCTAVE_ROOT}/common/cbor/libcbor/src/cbor/arrays.c
+    ${OCTAVE_ROOT}/common/cbor/libcbor/src/cbor/bytestrings.c
+    ${OCTAVE_ROOT}/common/cbor/libcbor/src/cbor/callbacks.c
+    ${OCTAVE_ROOT}/common/cbor/libcbor/src/cbor/floats_ctrls.c
+    ${OCTAVE_ROOT}/common/cbor/libcbor/src/cbor/ints.c
+    ${OCTAVE_ROOT}/common/cbor/libcbor/src/cbor/maps.c
+    ${OCTAVE_ROOT}/common/cbor/libcbor/src/cbor/serialization.c
+    ${OCTAVE_ROOT}/common/cbor/libcbor/src/cbor/strings.c
+    ${OCTAVE_ROOT}/common/cbor/libcbor/src/cbor/tags.c
+    ${OCTAVE_ROOT}/common/cbor/libcbor/src/cbor/internal/builder_callbacks.c
+    ${OCTAVE_ROOT}/common/cbor/libcbor/src/cbor/internal/memory_utils.c
+    ${OCTAVE_ROOT}/common/cbor/libcbor/src/cbor/internal/stack.c
+    ${OCTAVE_ROOT}/common/cbor/libcbor/src/cbor/internal/unicode.c
+#endif
+    ${OCTAVE_ROOT}/common/cbor/cbor_utils.c
+    ${OCTAVE_ROOT}/common/json/json_parser.c
+    ${OCTAVE_ROOT}/common/string/stringUtils.c
+    ${OCTAVE_ROOT}/common/cbor/jsoncbor.c
+}

--- a/components/octaveFormatter/octaveFormatter.c
+++ b/components/octaveFormatter/octaveFormatter.c
@@ -1,0 +1,1289 @@
+//--------------------------------------------------------------------------------------------------
+/**
+ * Snapshot formatter producing Octave CBOR output.
+ *
+ * Copyright (C) Sierra Wireless Inc.
+ */
+//--------------------------------------------------------------------------------------------------
+#include "octaveFormatter.h"
+
+#include "interfaces.h"
+
+#include "dataHub.h"
+#include "snapshot.h"
+#include "cbor_utils.h"
+
+
+/// Encoded bytes threshold under which formatter keeps buffering before sending data
+#define STREAMING_THRESHOLD_BYTES   HUB_MAX_STRING_BYTES
+
+/// Use query API custom flag as full tree encoding request
+#define OCTAVE_FLAG_FULL_TREE QUERY_SNAPSHOT_FLAG_CUSTOM
+
+/// Filter bitmask for live node detection.
+#define LIVE_FILTERS    (SNAPSHOT_FILTER_CREATED | SNAPSHOT_FILTER_NORMAL)
+/// Filter bitmask for all possible filters.
+#define ALL_FILTERS     (LIVE_FILTERS | SNAPSHOT_FILTER_DELETED)
+
+/// Internal formatter states.
+typedef enum
+{
+    STATE_START = 0,            ///< Beginning of the document.
+    STATE_SNAPSHOT_STEP,        ///< Trigger next outer state machine step.
+    STATE_NODE_NAME,            ///< Output node name.
+    STATE_NODE_OPEN,            ///< Output node opening and metadata.
+    STATE_NODE_VALUES,          ///< Output node timestamp and format for value.
+    STATE_NODE_VALUE_BODY,      ///< Output node value.
+    STATE_NODE_DEFAULT,         ///< Output formatting for default value.
+    STATE_NODE_DEFAULT_BODY,    ///< Output node default value.
+    STATE_JSON_EX,              ///< Output formatting for JSON example (JSON nodes only).
+    STATE_JSON_EX_BODY,         ///< Output node JSON example (JSON nodes only).
+    STATE_MAX                   ///< One larger than highest state value.
+} OctaveFormatterState_t;
+
+/// Octave formatter state.
+typedef struct OctaveFormatter
+{
+    snapshot_Formatter_t    base;           ///< Base type containing tree handling callbacks.
+    uint8_t                 buffer[HUB_MAX_STRING_BYTES * 2];   ///< Buffer for preparing formatted
+                                                                ///< output.
+    size_t                  remaining;      ///< Number of bytes available for encoding in buffer.
+    size_t                  encodedBytes;   ///< Number of bytes used in encoding buffer.
+    size_t                  next;           ///< Offset of the next byte to send.
+    size_t                  available;      ///< Number of bytes available to be sent.
+    bool                    isFullDump;     ///< Is the current dataHub dump a full or a diff one
+    bool                    skipNode;       ///< Does formatter need to skip content for this node?
+    OctaveFormatterState_t  nextState;      ///< Next state to transition to once currently buffered
+                                            ///< data is sent.
+    le_fdMonitor_Ref_t      monitor;        ///< FD monitor for output stream.
+} OctaveFormatter_t;
+
+//--------------------------------------------------------------------------------------------------
+/*
+ * Callback for an internal formatter state machine step.
+ */
+//--------------------------------------------------------------------------------------------------
+typedef void (*OctaveFormatterStep_t)
+(
+    OctaveFormatter_t *octaveFormatter ///< Formatter instance.
+);
+
+// Forward reference.
+static void Step(OctaveFormatter_t *octaveFormatter);
+
+
+//--------------------------------------------------------------------------------------------------
+/*
+ * Get the string representation of a filter.
+ *
+ * @return const char * representing filter
+ */
+//--------------------------------------------------------------------------------------------------
+static const char * FilterToString
+(
+    uint32_t filter ///< filter value to translate
+)
+{
+    if (LIVE_FILTERS == (filter & ALL_FILTERS))
+    {
+        return "LIVE";
+    }
+    else if (SNAPSHOT_FILTER_CREATED == (filter & ALL_FILTERS))
+    {
+        return "NEW";
+    }
+    else if (SNAPSHOT_FILTER_NORMAL == (filter & ALL_FILTERS))
+    {
+        return "MODIFIED";
+    }
+    else if (SNAPSHOT_FILTER_DELETED == (filter & ALL_FILTERS))
+    {
+        return "DELETED";
+    }
+    else
+    {
+        return "UNKNOWN";
+    }
+}
+
+//--------------------------------------------------------------------------------------------------
+/*
+ * Send some data from the buffer to the output stream.
+ *
+ * @return -1 on error, 0 if all data was sent, or 1 if more data remains to be sent.
+ */
+//--------------------------------------------------------------------------------------------------
+static int SendData
+(
+    OctaveFormatter_t   *octaveFormatter,   ///< Formatter instance.
+    int                  stream             ///< Output stream FD.
+)
+{
+    const uint8_t *start = &octaveFormatter->buffer[octaveFormatter->next];
+    ssize_t      count;
+
+    if (octaveFormatter->available == 0)
+    {
+        LE_DEBUG("Nothing to send");
+        return 1;
+    }
+
+    count = le_fd_Write(stream, start, octaveFormatter->available);
+    if (count < 0)
+    {
+        if (EAGAIN == errno)
+        {
+            // Data not read yet by other side, keep new data in buffer and wait
+            return 1;
+        }
+        else
+        {
+            // other errors are fatal
+            LE_ERROR("Failed to write to stream with errno: %d", errno);
+            return -1;
+        }
+    }
+    else if (count < (ssize_t)octaveFormatter->available)
+    {
+        // Didn't send all of the available data.
+        octaveFormatter->next += count;
+        octaveFormatter->available -= count;
+        LE_ASSERT(octaveFormatter->next < sizeof(octaveFormatter->buffer));
+        return 1;
+    }
+    else
+    {
+        // We've sent everything in the buffer.
+        octaveFormatter->next = 0;
+        octaveFormatter->available = 0;
+        le_fdMonitor_Disable(octaveFormatter->monitor, POLLOUT);
+        return 0;
+    }
+}
+
+//--------------------------------------------------------------------------------------------------
+/*
+ * Handle an FD or manually triggered event on the formatted output stream.
+ */
+//--------------------------------------------------------------------------------------------------
+static void HandleEvents
+(
+    OctaveFormatter_t   *octaveFormatter,  ///< Formatter instance.
+    int                 fd,                ///< Output stream file descriptor.
+    short               events             ///< FD event bitfield.
+)
+{
+    int status;
+
+    LE_DEBUG("Handling events 0x%04X", events);
+    if (events & POLLOUT)
+    {
+        // Can send more data, so do it.
+        status = SendData(octaveFormatter, fd);
+        if (status < 0)
+        {
+            LE_ERROR("Failed to send data");
+            // Error sending data, so abort the snapshot.
+            snapshot_End(LE_CLOSED);
+            return;
+        }
+        else if (status == 0)
+        {
+            LE_DEBUG("Wrote all %zu bytes to pipe", octaveFormatter->encodedBytes);
+            // Sent all the available data, take action to get more.
+            octaveFormatter->remaining = sizeof(octaveFormatter->buffer);
+            octaveFormatter->encodedBytes = 0;
+            Step(octaveFormatter);
+            return;
+        }
+        else
+        {
+            LE_DEBUG("Wrote %zu bytes to pipe, %zu remaining",
+                     octaveFormatter->encodedBytes - octaveFormatter->available,
+                     octaveFormatter->available);
+        }
+
+        // If we are here there is still more data to send from the buffer, so wait
+        // until the next POLLOUT.
+    }
+
+    if (events & POLLHUP)
+    {
+        LE_ERROR("Stream closed unexpectedly");
+        // Stream was closed for some reason, nothing we can do except terminate the snapshot.
+        snapshot_End(LE_CLOSED);
+    }
+    else if (events & ~POLLOUT)
+    {
+        LE_ERROR("Unsupported event received");
+        // Any other condition is an error, so terminate the snapshot.
+        snapshot_End(LE_FAULT);
+    }
+}
+
+//--------------------------------------------------------------------------------------------------
+/*
+ * Handle an event on the formatted output stream.
+ */
+//--------------------------------------------------------------------------------------------------
+static void StreamHandler
+(
+    int     fd,     ///< Output stream file descriptor.
+    short   events  ///< Event bitmask.
+)
+{
+    OctaveFormatter_t *octaveFormatter = le_fdMonitor_GetContextPtr();
+
+    LE_DEBUG("Stream event");
+    HandleEvents(octaveFormatter, fd, events);
+}
+
+//--------------------------------------------------------------------------------------------------
+/*
+ * Handle an explicitly triggered event to write to the formatted output stream.
+ */
+//--------------------------------------------------------------------------------------------------
+static void ExplicitSendHandler
+(
+    OctaveFormatter_t   *octaveFormatter,  ///< Formatter instance.
+    void                *unused            ///< Unused.
+)
+{
+    int fd = le_fdMonitor_GetFd(octaveFormatter->monitor);
+
+    LE_UNUSED(unused);
+
+    LE_DEBUG("Explicit send");
+    HandleEvents(octaveFormatter, fd, POLLOUT);
+}
+
+//--------------------------------------------------------------------------------------------------
+/*
+ * (Re)enable events on formatted output stream.
+ */
+//--------------------------------------------------------------------------------------------------
+static void EnableSend
+(
+    OctaveFormatter_t   *octaveFormatter,   ///< Formatter instance.
+    size_t               available          ///< Number of available bytes to send.
+)
+{
+    LE_ASSERT(octaveFormatter->next == 0);
+    LE_DEBUG("Sending %zu bytes", available);
+    octaveFormatter->available = available;
+    le_fdMonitor_Enable(octaveFormatter->monitor, POLLOUT);
+
+    // Explicitly trigger an attempt to send, since the stream might be sitting ready and therefore
+    // not generate a new POLLOUT.
+    le_event_QueueFunction((le_event_DeferredFunc_t) &ExplicitSendHandler, octaveFormatter, NULL);
+}
+
+//--------------------------------------------------------------------------------------------------
+/*
+ * Send data in encoded buffer if above a given threshold,
+ * otherwise advance formatter state machine.
+ * Sending data may be forced (ignoring threshold, useful when no more operation to perform).
+ */
+//--------------------------------------------------------------------------------------------------
+static void SendOrAdvance
+(
+    OctaveFormatter_t   *octaveFormatter,   ///< Formatter instance.
+    bool                forceSend           ///< Force send even if conditions are not met.
+)
+{
+    if (forceSend || (octaveFormatter->encodedBytes >= STREAMING_THRESHOLD_BYTES))
+    {
+        EnableSend(octaveFormatter, octaveFormatter->encodedBytes);
+    }
+    else
+    {
+        Step(octaveFormatter);
+    }
+}
+
+//--------------------------------------------------------------------------------------------------
+/*
+ * Octave creates internal nodes for observation.
+ * These are:
+ *  - direct children of /app/cloudInterface node
+ *  - of type INPUT/OUTPUT/OBSERVATION
+ * They must not be reported as part of the tree.
+ *
+ * @return True if node identified as internal Octave node.
+ */
+//--------------------------------------------------------------------------------------------------
+static bool IsInternalNode(
+    resTree_EntryRef_t node ///< Node to check for
+)
+{
+    admin_EntryType_t   entryType = resTree_GetEntryType(node);
+
+    if ((ADMIN_ENTRY_TYPE_INPUT == entryType) ||
+        (ADMIN_ENTRY_TYPE_OUTPUT == entryType) ||
+        (ADMIN_ENTRY_TYPE_OBSERVATION == entryType))
+    {
+        resTree_EntryRef_t parentNode = resTree_GetParent(node);
+        if (NULL != parentNode && (0 == strcmp("cloudInterface", resTree_GetEntryName(parentNode))))
+        {
+            return true;
+        }
+    }
+
+    return false;
+}
+
+//--------------------------------------------------------------------------------------------------
+/*
+ * Begin formatting the overall resource tree.
+ */
+//--------------------------------------------------------------------------------------------------
+static void StartTree
+(
+    snapshot_Formatter_t *formatter ///< Formatter instance
+)
+{
+    OctaveFormatter_t *octaveFormatter = CONTAINER_OF(formatter, OctaveFormatter_t, base);
+
+    le_result_t res = LE_OK;
+    size_t encoded = octaveFormatter->encodedBytes;
+    size_t remaining = octaveFormatter->remaining;
+
+    LE_ASSERT(formatter->filter & ALL_FILTERS);
+
+    LE_DEBUG("Encode tree for filter %s", FilterToString(formatter->filter));
+
+    // 1st pass for full/diff tree: open array, log timestamp and open map for all/new items
+    if (SNAPSHOT_FILTER_CREATED == (formatter->filter & LIVE_FILTERS) ||
+        LIVE_FILTERS == (formatter->filter & LIVE_FILTERS))
+    {
+        if (LE_OK != (res = cbor_utils_EncodeArrayStart(octaveFormatter->buffer + encoded,
+                                                        &remaining, &encoded,
+                                                        octaveFormatter->isFullDump ? 2 : 4)))
+        {
+            goto cborerror;
+        }
+        LE_DEBUG("Added array %zu", encoded);
+        LE_DUMP(octaveFormatter->buffer, encoded);
+        /* Octave uses the time in milliseconds as an unsigned int, whereas snapshot_GetTimestamp()
+        * returns whole seconds as double
+        */
+        struct timeval tv;
+        gettimeofday(&tv, NULL);
+        uint64_t ts = (uint64_t)(tv.tv_sec) * 1000 + (uint64_t)(tv.tv_usec) / 1000;
+
+        if (LE_OK != (res = cbor_utils_EncodePositiveInt(octaveFormatter->buffer + encoded,
+                                                         &remaining, &encoded, ts)))
+        {
+            goto cborerror;
+        }
+        LE_DEBUG("1st pass encoding start %zu", encoded);
+        LE_DUMP(octaveFormatter->buffer, encoded);
+        if (LE_OK != (res = cbor_utils_EncodeIndefMapStart(octaveFormatter->buffer + encoded,
+                                                           &remaining, &encoded)))
+        {
+            goto cborerror;
+        }
+        LE_INFO("1st pass encoded start %zu", encoded);
+        LE_DUMP(octaveFormatter->buffer, encoded);
+    }
+    // 2nd pass for diff tree: open map for modified items
+    else if (SNAPSHOT_FILTER_NORMAL == (formatter->filter & LIVE_FILTERS))
+    {
+        if (LE_OK != (res = cbor_utils_EncodeIndefMapStart(octaveFormatter->buffer + encoded,
+                                                           &remaining, &encoded)))
+        {
+            goto cborerror;
+        }
+        LE_DEBUG("2nd pass  Total: %zu", encoded);
+        LE_DUMP(octaveFormatter->buffer, encoded);
+    }
+    // 3rd pass for diff tree: open array for deleted items
+    else if (SNAPSHOT_FILTER_DELETED == (formatter->filter & ALL_FILTERS))
+    {
+        if (LE_OK != (res = cbor_utils_EncodeIndefArrayStart(octaveFormatter->buffer + encoded,
+                                                             &remaining, &encoded)))
+        {
+            goto cborerror;
+        }
+        LE_DEBUG("3rd pass  Total: %zu", encoded);
+        LE_DUMP(octaveFormatter->buffer, encoded);
+    }
+    else
+    {
+        LE_FATAL("Unexpected filter requested");
+    }
+
+    // Now we wait for the buffer to drain and call snapshot_Step() when it is done.
+    octaveFormatter->skipNode = true;
+    octaveFormatter->nextState = STATE_SNAPSHOT_STEP;
+    octaveFormatter->encodedBytes = encoded;
+    octaveFormatter->remaining = remaining;
+    SendOrAdvance(octaveFormatter, false);
+    return;
+
+cborerror:
+    LE_ERROR("Failed to encode data with error %s", LE_RESULT_TXT(res));
+    snapshot_End(res);
+}
+
+//--------------------------------------------------------------------------------------------------
+/*
+ * Begin formatting a resource tree node.
+ */
+//--------------------------------------------------------------------------------------------------
+static void BeginNode
+(
+    snapshot_Formatter_t *formatter ///< Formatter instance.
+)
+{
+    OctaveFormatter_t *octaveFormatter = CONTAINER_OF(formatter, OctaveFormatter_t, base);
+
+    LE_ASSERT(formatter->filter & ALL_FILTERS);
+
+    // evaluate if node content should be skipped (move on to child node):
+    //  - root node is skipped
+    //  - Octave internal node are skipped
+    //  - added/modified nodes that are not input/ouput/observation are skipped
+    //  - for deleted nodes tracking: only the actually deleted node is considered
+    resTree_EntryRef_t  node = snapshot_GetNode();
+    resTree_EntryRef_t  root = snapshot_GetRoot();
+    admin_EntryType_t   entryType = resTree_GetEntryType(node);
+    octaveFormatter->skipNode = ((root == node) ||
+                                 IsInternalNode(node) ||
+                                 (!(formatter->filter & SNAPSHOT_FILTER_DELETED) &&
+                                  !((ADMIN_ENTRY_TYPE_INPUT == entryType) ||
+                                    (ADMIN_ENTRY_TYPE_OUTPUT == entryType) ||
+                                    (ADMIN_ENTRY_TYPE_OBSERVATION == entryType))) ||
+                                 ((formatter->filter & SNAPSHOT_FILTER_DELETED) &&
+                                  !resTree_IsDeleted(node)));
+
+    if (octaveFormatter->skipNode)
+    {
+        // Move directly to opening node as this one's content is irrelevant
+        LE_DEBUG("Skip node '%s'", resTree_GetEntryName(node));
+        octaveFormatter->nextState = STATE_NODE_OPEN;
+        Step(octaveFormatter);
+    }
+    else
+    {
+        // Relevant node, move on to its name
+        octaveFormatter->nextState = STATE_NODE_NAME;
+        Step(octaveFormatter);
+    }
+}
+
+//--------------------------------------------------------------------------------------------------
+/*
+ * Write the node name part of the object key to the buffer.
+ */
+//--------------------------------------------------------------------------------------------------
+static void NodeName
+(
+    OctaveFormatter_t *octaveFormatter  ///< Formatter instance.
+)
+{
+    resTree_EntryRef_t node = snapshot_GetNode();
+    char path[HUB_MAX_RESOURCE_PATH_BYTES] = {0};
+    ssize_t pathLen = 0;
+
+    le_result_t res = LE_OK;
+    size_t encodedBytes = octaveFormatter->encodedBytes;
+    size_t remaining = octaveFormatter->remaining;
+
+
+    LE_ASSERT(octaveFormatter->base.filter & ALL_FILTERS);
+    LE_ASSERT(!octaveFormatter->skipNode);
+
+    /* path returned below does not begin with '/', whereas the backend expects
+     * this to be included in the cbor message
+     */
+    path[0] = '/';
+    /* Get node's full path from root. If this fails, abort snapshot. resTree_GetPath() returns
+     * -ve legato error code on failure
+     */
+    if (0 > (pathLen = resTree_GetPath((char *)(path + 1), HUB_MAX_RESOURCE_PATH_BYTES - 1,
+                                       snapshot_GetRoot(), node)))
+    {
+        LE_ERROR("Failed to retrieve node's path for node '%s'", resTree_GetEntryName(node));
+        res = (le_result_t)pathLen;
+        goto cborerror;
+    }
+    if (LE_OK != (res = cbor_utils_EncodeString(octaveFormatter->buffer + encodedBytes,
+                                                &remaining, &encodedBytes, path)))
+    {
+        goto cborerror;
+    }
+    octaveFormatter->nextState = STATE_NODE_OPEN;
+    octaveFormatter->encodedBytes = encodedBytes;
+    octaveFormatter->remaining = remaining;
+    SendOrAdvance(octaveFormatter, false);
+    return;
+
+cborerror:
+    LE_ERROR("Failed to encode data with error %s", LE_RESULT_TXT(res));
+    snapshot_End(res);
+}
+
+//--------------------------------------------------------------------------------------------------
+/*
+ * Write the node opening preamble and its metadata to the buffer.
+ */
+//--------------------------------------------------------------------------------------------------
+static void NodeOpen
+(
+    OctaveFormatter_t *octaveFormatter  ///< Formatter instance.
+)
+{
+    resTree_EntryRef_t  node = snapshot_GetNode();
+    admin_EntryType_t   entryType = resTree_GetEntryType(node);
+
+    le_result_t res = LE_OK;
+    size_t encodedBytes = octaveFormatter->encodedBytes;
+    size_t remaining = octaveFormatter->remaining;
+
+    LE_ASSERT(octaveFormatter->base.filter & ALL_FILTERS);
+
+    // for added/modified nodes: open a map to dump their content
+    if (octaveFormatter->base.filter & LIVE_FILTERS && !octaveFormatter->skipNode)
+    {
+        io_DataType_t dataType = resTree_GetDataType(node);
+        int64_t metadata = 0;
+        metadata += entryType;
+        metadata += 10*dataType;
+        metadata += 100*resTree_IsMandatory(node);
+
+        LE_DEBUG("Open node '%s'", resTree_GetEntryName(node));
+        if (LE_OK != (res = cbor_utils_EncodeIndefMapStart(octaveFormatter->buffer + encodedBytes,
+                                                           &remaining, &encodedBytes)))
+        {
+            goto cborerror;
+        }
+        if (LE_OK != (res = cbor_utils_EncodeString(octaveFormatter->buffer + encodedBytes,
+                                                    &remaining, &encodedBytes, (char*)"y")))
+        {
+            goto cborerror;
+        }
+        if (LE_OK != (res = cbor_utils_EncodeInt(octaveFormatter->buffer + encodedBytes,
+                                                 &remaining, &encodedBytes, metadata)))
+        {
+            goto cborerror;
+        }
+    }
+    // skipped nodes need no formatting and deleted ones are dumped by name only
+    else
+    {
+        octaveFormatter->skipNode = false;
+        octaveFormatter->nextState = STATE_SNAPSHOT_STEP;
+        Step(octaveFormatter);
+        return;
+    }
+
+    octaveFormatter->skipNode = false;
+
+    switch (entryType)
+    {
+        case ADMIN_ENTRY_TYPE_INPUT:
+        case ADMIN_ENTRY_TYPE_OUTPUT:
+        case ADMIN_ENTRY_TYPE_OBSERVATION:
+            if (snapshot_IsTimely(node))
+            {
+                // Node values have been set, output them
+                octaveFormatter->nextState = STATE_NODE_VALUES;
+            }
+            else
+            {
+                // Node is still empty, move on to next one
+                octaveFormatter->nextState = STATE_SNAPSHOT_STEP;
+            }
+            break;
+        case ADMIN_ENTRY_TYPE_NAMESPACE:
+        case ADMIN_ENTRY_TYPE_PLACEHOLDER:
+        default:
+            LE_FATAL("Unexpected entry type: %d", entryType);
+            break;
+    }
+    octaveFormatter->encodedBytes = encodedBytes;
+    octaveFormatter->remaining = remaining;
+    SendOrAdvance(octaveFormatter, false);
+    return;
+
+cborerror:
+    LE_ERROR("Failed to encode data with error %s", LE_RESULT_TXT(res));
+    snapshot_End(res);
+}
+
+//--------------------------------------------------------------------------------------------------
+/*
+ * Format node's timestamp and prepare for its value.
+ */
+//--------------------------------------------------------------------------------------------------
+static void NodeValues
+(
+    OctaveFormatter_t *octaveFormatter  ///< Formatter instance.
+)
+{
+    resTree_EntryRef_t  node = snapshot_GetNode();
+    dataSample_Ref_t    sample = resTree_GetCurrentValue(node);
+    io_DataType_t       dataType = resTree_GetDataType(node);
+
+    le_result_t res = LE_OK;
+    size_t encodedBytes = octaveFormatter->encodedBytes;
+    size_t remaining = octaveFormatter->remaining;
+
+    LE_ASSERT(octaveFormatter->base.filter & LIVE_FILTERS);
+
+    if (NULL == sample)
+    {
+        // nodes with no value should not have their timestamp set
+        // NodeOpen call should have jumped directly to next node
+        // allow snapshot to continue as it does not creates issue but warn about it
+        LE_WARN("Node '%s' has no value, should not have reached this function",
+                resTree_GetEntryName(snapshot_GetNode()));
+        octaveFormatter->nextState = STATE_SNAPSHOT_STEP;
+        Step(octaveFormatter);
+        return;
+    }
+
+    LE_DEBUG("Node timestamp for '%s'", resTree_GetEntryName(node));
+
+    double timestampDouble = dataSample_GetTimestamp(sample);
+    uint64_t timestamp = (uint64_t)timestampDouble;
+    // Handle clients who use milliseconds, not seconds
+    if (timestamp >= 10000000000){
+        timestamp = timestamp / 1000;
+    }
+
+    if (LE_OK != (res = cbor_utils_EncodeString(octaveFormatter->buffer + encodedBytes,
+                                                &remaining, &encodedBytes, (char*)"t")))
+    {
+        goto cborerror;
+    }
+    if (LE_OK != (res = cbor_utils_EncodePositiveInt(octaveFormatter->buffer + encodedBytes,
+                                                     &remaining, &encodedBytes, timestamp)))
+    {
+        goto cborerror;
+    }
+
+    switch (dataType)
+    {
+        case IO_DATA_TYPE_TRIGGER:
+            octaveFormatter->nextState = STATE_SNAPSHOT_STEP;
+            break;
+
+        case IO_DATA_TYPE_BOOLEAN:
+        case IO_DATA_TYPE_NUMERIC:
+        case IO_DATA_TYPE_STRING:
+        case IO_DATA_TYPE_JSON:
+            if (LE_OK != (res = cbor_utils_EncodeString(octaveFormatter->buffer + encodedBytes,
+                                                        &remaining, &encodedBytes, (char*)"v")))
+            {
+                goto cborerror;
+            }
+            octaveFormatter->nextState = STATE_NODE_VALUE_BODY;
+            break;
+    }
+    octaveFormatter->encodedBytes = encodedBytes;
+    octaveFormatter->remaining = remaining;
+    SendOrAdvance(octaveFormatter, false);
+    return;
+
+cborerror:
+    LE_ERROR("Failed to encode data with error %s", LE_RESULT_TXT(res));
+    snapshot_End(res);
+}
+
+//--------------------------------------------------------------------------------------------------
+/*
+ * Write the node value to the buffer.
+ */
+//--------------------------------------------------------------------------------------------------
+static void NodeValueBody
+(
+    OctaveFormatter_t *octaveFormatter  ///< Formatter instance.
+)
+{
+    resTree_EntryRef_t  node = snapshot_GetNode();
+    dataSample_Ref_t    sample = resTree_GetCurrentValue(node);
+    io_DataType_t       dataType = resTree_GetDataType(node);
+
+    le_result_t res = LE_OK;
+    size_t encodedBytes = octaveFormatter->encodedBytes;
+    size_t remaining = octaveFormatter->remaining;
+
+    LE_ASSERT(octaveFormatter->base.filter & LIVE_FILTERS);
+    LE_ASSERT(sample != NULL);
+
+    LE_DEBUG("Node value for '%s'", resTree_GetEntryName(node));
+
+    // The string/JSON copied in should never be larger than sizeof(octaveFormatter->buffer), so we
+    // can assert if this overflows.
+    if (IO_DATA_TYPE_BOOLEAN == dataType)
+    {
+        if (LE_OK != (res = cbor_utils_EncodeBool(octaveFormatter->buffer + encodedBytes,
+                                                  &remaining, &encodedBytes,
+                                                  dataSample_GetBoolean(sample))))
+        {
+            goto cborerror;
+        }
+    }
+    else if (IO_DATA_TYPE_NUMERIC == dataType)
+    {
+        if (LE_OK != (res = cbor_utils_EncodeDouble(octaveFormatter->buffer + encodedBytes,
+                                                    &remaining, &encodedBytes,
+                                                    dataSample_GetNumeric(sample))))
+        {
+            goto cborerror;
+        }
+    }
+    else if (IO_DATA_TYPE_STRING == dataType)
+    {
+        if (LE_OK != (res = cbor_utils_EncodeString(octaveFormatter->buffer + encodedBytes,
+                                                    &remaining, &encodedBytes,
+                                                    dataSample_GetString(sample))))
+        {
+            goto cborerror;
+        }
+    }
+    else if (IO_DATA_TYPE_JSON == dataType)
+    {
+        if (LE_OK != (res = cbor_utils_EncodeString(octaveFormatter->buffer + encodedBytes,
+                                                    &remaining, &encodedBytes,
+                                                    dataSample_GetJson(sample))))
+        {
+            goto cborerror;
+        }
+    }
+    else
+    {
+        // no other data type should end up in this function
+        LE_FATAL("Unexpected data type %d", dataType);
+    }
+
+    octaveFormatter->nextState = STATE_NODE_DEFAULT;
+    octaveFormatter->encodedBytes = encodedBytes;
+    octaveFormatter->remaining = remaining;
+    SendOrAdvance(octaveFormatter, false);
+    return;
+
+cborerror:
+    LE_ERROR("Failed to encode data with error %s", LE_RESULT_TXT(res));
+    snapshot_End(res);
+}
+
+//--------------------------------------------------------------------------------------------------
+/*
+ * Checks for default value and proceed accordingly.
+ */
+//--------------------------------------------------------------------------------------------------
+static void NodeDefaultValue
+(
+    OctaveFormatter_t *octaveFormatter  ///< Formatter instance.
+)
+{
+    resTree_EntryRef_t  node = snapshot_GetNode();
+    io_DataType_t       dataType = resTree_GetDataType(node);
+    admin_EntryType_t   entryType = resTree_GetEntryType(node);
+
+    le_result_t res = LE_OK;
+    size_t encodedBytes = octaveFormatter->encodedBytes;
+    size_t remaining = octaveFormatter->remaining;
+
+    LE_ASSERT(octaveFormatter->base.filter & LIVE_FILTERS);
+
+    if (resTree_HasDefault(node))
+    {
+        if (LE_OK != (res = cbor_utils_EncodeString(octaveFormatter->buffer + encodedBytes,
+                                                    &remaining, &encodedBytes, (char*)"d")))
+        {
+            goto cborerror;
+        }
+        octaveFormatter->nextState = STATE_NODE_DEFAULT_BODY;
+        octaveFormatter->encodedBytes = encodedBytes;
+        octaveFormatter->remaining = remaining;
+        SendOrAdvance(octaveFormatter, false);
+    }
+    else if (IO_DATA_TYPE_JSON == dataType && ADMIN_ENTRY_TYPE_INPUT == entryType &&
+             resTree_IsJsonExampleChanged(node))
+    {
+        octaveFormatter->nextState = STATE_JSON_EX;
+        Step(octaveFormatter);
+    }
+    else
+    {
+        octaveFormatter->nextState = STATE_SNAPSHOT_STEP;
+        Step(octaveFormatter);
+    }
+    return;
+
+cborerror:
+    LE_ERROR("Failed to encode data with error %s", LE_RESULT_TXT(res));
+    snapshot_End(res);
+}
+
+//--------------------------------------------------------------------------------------------------
+/*
+ * Write the node default value to the buffer.
+ */
+//--------------------------------------------------------------------------------------------------
+static void NodeDefaultValueBody
+(
+    OctaveFormatter_t *octaveFormatter  ///< Formatter instance.
+)
+{
+    resTree_EntryRef_t  node = snapshot_GetNode();
+    io_DataType_t       dataType = resTree_GetDefaultDataType(node);
+    dataSample_Ref_t    sample = resTree_GetDefaultValue(node);
+
+    le_result_t res = LE_OK;
+    size_t encodedBytes = octaveFormatter->encodedBytes;
+    size_t remaining = octaveFormatter->remaining;
+
+    LE_ASSERT(octaveFormatter->base.filter & LIVE_FILTERS);
+    LE_ASSERT(resTree_HasDefault(node));
+
+    LE_DEBUG("Node default value for '%s'", resTree_GetEntryName(node));
+
+    if (IO_DATA_TYPE_BOOLEAN == dataType)
+    {
+        if (LE_OK != (res = cbor_utils_EncodeBool(octaveFormatter->buffer + encodedBytes,
+                                                  &remaining, &encodedBytes,
+                                                  dataSample_GetBoolean(sample))))
+        {
+            goto cborerror;
+        }
+    }
+    else if (IO_DATA_TYPE_NUMERIC == dataType)
+    {
+        if (LE_OK != (res = cbor_utils_EncodeDouble(octaveFormatter->buffer + encodedBytes,
+                                                    &remaining, &encodedBytes,
+                                                    dataSample_GetNumeric(sample))))
+        {
+            goto cborerror;
+        }
+    }
+    else if (IO_DATA_TYPE_STRING == dataType)
+    {
+        if (LE_OK != (res = cbor_utils_EncodeString(octaveFormatter->buffer + encodedBytes,
+                                                    &remaining, &encodedBytes,
+                                                    dataSample_GetString(sample))))
+        {
+            goto cborerror;
+        }
+    }
+    else if (IO_DATA_TYPE_JSON == dataType)
+    {
+        if (LE_OK != (res = cbor_utils_EncodeString(octaveFormatter->buffer + encodedBytes,
+                                                    &remaining, &encodedBytes,
+                                                    dataSample_GetJson(sample))))
+        {
+            goto cborerror;
+        }
+    }
+    else
+    {
+        // no other data type should end up in this function
+        LE_FATAL("Unexpected data type %d", dataType);
+    }
+
+    if (IO_DATA_TYPE_JSON == resTree_GetDataType(node) &&
+        ADMIN_ENTRY_TYPE_INPUT == resTree_GetEntryType(node) &&
+        resTree_IsJsonExampleChanged(node))
+    {
+        octaveFormatter->nextState = STATE_JSON_EX;
+    }
+    else
+    {
+        octaveFormatter->nextState = STATE_SNAPSHOT_STEP;
+    }
+    octaveFormatter->encodedBytes = encodedBytes;
+    octaveFormatter->remaining = remaining;
+    SendOrAdvance(octaveFormatter, false);
+    return;
+
+cborerror:
+    LE_ERROR("Failed to encode data with error %s", LE_RESULT_TXT(res));
+    snapshot_End(res);
+}
+
+//--------------------------------------------------------------------------------------------------
+/*
+ * Formatting for JSON example.
+ */
+//--------------------------------------------------------------------------------------------------
+static void NodeJsonExample
+(
+    OctaveFormatter_t *octaveFormatter  ///< Formatter instance.
+)
+{
+    resTree_EntryRef_t  node = snapshot_GetNode();
+    io_DataType_t       dataType = resTree_GetDataType(node);
+
+    le_result_t res = LE_OK;
+    size_t encodedBytes = octaveFormatter->encodedBytes;
+    size_t remaining = octaveFormatter->remaining;
+
+    LE_ASSERT(octaveFormatter->base.filter & LIVE_FILTERS);
+    LE_ASSERT(IO_DATA_TYPE_JSON == dataType);
+    LE_ASSERT(resTree_IsJsonExampleChanged(node));
+
+    if (LE_OK != (res = cbor_utils_EncodeString(octaveFormatter->buffer + encodedBytes,
+                                                &remaining, &encodedBytes, (char*)"s")))
+    {
+        goto cborerror;
+    }
+    octaveFormatter->nextState = STATE_JSON_EX_BODY;
+    octaveFormatter->encodedBytes = encodedBytes;
+    octaveFormatter->remaining = remaining;
+    SendOrAdvance(octaveFormatter, false);
+    return;
+
+cborerror:
+    LE_ERROR("Failed to encode data with error %s", LE_RESULT_TXT(res));
+    snapshot_End(res);
+}
+
+//--------------------------------------------------------------------------------------------------
+/*
+ * Write the node JSON example.
+ */
+//--------------------------------------------------------------------------------------------------
+static void NodeJsonExampleBody
+(
+    OctaveFormatter_t *octaveFormatter  ///< Formatter instance.
+)
+{
+    resTree_EntryRef_t  node = snapshot_GetNode();
+    io_DataType_t       dataType = resTree_GetDataType(node);
+
+    le_result_t res = LE_OK;
+    size_t encodedBytes = octaveFormatter->encodedBytes;
+    size_t remaining = octaveFormatter->remaining;
+
+    LE_ASSERT(octaveFormatter->base.filter & LIVE_FILTERS);
+    LE_ASSERT(IO_DATA_TYPE_JSON == dataType);
+    LE_ASSERT(resTree_IsJsonExampleChanged(node));
+
+    LE_DEBUG("Node JSON example for '%s'", resTree_GetEntryName(node));
+
+    // The string/JSON copied in should never be larger than sizeof(octaveFormatter->buffer), so we
+    // can assert if this overflows.
+    if (LE_OK != (res = cbor_utils_EncodeString(octaveFormatter->buffer + encodedBytes,
+                                                &remaining, &encodedBytes,
+                                                dataSample_GetJson(resTree_GetJsonExample(node)))))
+    {
+        goto cborerror;
+    }
+    resTree_ClearJsonExampleChanged(node);
+
+    octaveFormatter->nextState = STATE_SNAPSHOT_STEP;
+    octaveFormatter->encodedBytes = encodedBytes;
+    octaveFormatter->remaining = remaining;
+    SendOrAdvance(octaveFormatter, false);
+    return;
+
+cborerror:
+    LE_ERROR("Failed to encode data with error %s", LE_RESULT_TXT(res));
+    snapshot_End(res);
+}
+
+//--------------------------------------------------------------------------------------------------
+/*
+ * Finish formatting an object.
+ */
+//--------------------------------------------------------------------------------------------------
+static void EndObject
+(
+    snapshot_Formatter_t *formatter ///< Formatter instance.
+)
+{
+    OctaveFormatter_t *octaveFormatter = CONTAINER_OF(formatter, OctaveFormatter_t, base);
+
+    le_result_t res = LE_OK;
+    size_t encodedBytes = octaveFormatter->encodedBytes;
+    size_t remaining = octaveFormatter->remaining;
+
+    LE_ASSERT(formatter->filter & ALL_FILTERS);
+
+    LE_DEBUG("Closing node");
+
+    // Now we wait for the buffer to drain and call snapshot_Step() when it is done.
+    octaveFormatter->nextState = STATE_SNAPSHOT_STEP;
+
+    // evaluate if node content was skipped (overwritten when accessed its child)
+    //  - root node is skipped
+    //  - added/modified nodes that are not input/ouput/observation are skipped
+    //  - for deleted nodes tracking: only the actually deleted node is considered
+    resTree_EntryRef_t  node = snapshot_GetNode();
+    resTree_EntryRef_t  root = snapshot_GetRoot();
+    admin_EntryType_t   entryType = resTree_GetEntryType(node);
+    octaveFormatter->skipNode = ((root == node) ||
+                                 (!(formatter->filter & SNAPSHOT_FILTER_DELETED) &&
+                                  !((ADMIN_ENTRY_TYPE_INPUT == entryType) ||
+                                    (ADMIN_ENTRY_TYPE_OUTPUT == entryType) ||
+                                    (ADMIN_ENTRY_TYPE_OBSERVATION == entryType))) ||
+                                 ((formatter->filter & SNAPSHOT_FILTER_DELETED) &&
+                                  !resTree_IsDeleted(node)));
+
+    // for added/modified nodes that were not skipped: close map
+    if (formatter->filter & LIVE_FILTERS && !octaveFormatter->skipNode)
+    {
+        if (LE_OK != (res = cbor_utils_EncodeBreak(octaveFormatter->buffer + encodedBytes,
+                                                   &remaining, &encodedBytes)))
+        {
+            goto cborerror;
+        }
+        octaveFormatter->encodedBytes = encodedBytes;
+        octaveFormatter->remaining = remaining;
+        SendOrAdvance(octaveFormatter, false);
+    }
+    // for skipped/deleted nodes, no formatting needed
+    else
+    {
+        Step(octaveFormatter);
+    }
+    return;
+
+cborerror:
+    LE_ERROR("Failed to encode data with error %s", LE_RESULT_TXT(res));
+    snapshot_End(res);
+}
+
+//--------------------------------------------------------------------------------------------------
+/*
+ * Finish formatting a tree.
+ */
+//--------------------------------------------------------------------------------------------------
+static void EndTree
+(
+    snapshot_Formatter_t *formatter ///< Formatter instance.
+)
+{
+    OctaveFormatter_t *octaveFormatter = CONTAINER_OF(formatter, OctaveFormatter_t, base);
+
+    le_result_t res = LE_OK;
+    size_t encodedBytes = octaveFormatter->encodedBytes;
+    size_t remaining = octaveFormatter->remaining;
+
+    LE_ASSERT(formatter->filter & ALL_FILTERS);
+
+    LE_DEBUG("Finished encoding tree for filter %s", FilterToString(formatter->filter));
+    octaveFormatter->nextState = STATE_SNAPSHOT_STEP;
+
+    // full tree dump ends after 1 pass: close nodes map
+    if (octaveFormatter->isFullDump)
+    {
+        if (LE_OK != (res = cbor_utils_EncodeBreak(octaveFormatter->buffer + encodedBytes,
+                                                   &remaining, &encodedBytes)))
+        {
+            goto cborerror;
+        }
+        formatter->scan = false;
+    }
+    // diff tree 1st pass end (added nodes): close nodes map and move on to modified nodes
+    else if (SNAPSHOT_FILTER_CREATED == (formatter->filter & LIVE_FILTERS))
+    {
+        LE_INFO("1st pass ending Total: %zu", encodedBytes);
+        LE_DUMP(octaveFormatter->buffer, encodedBytes);
+        if (LE_OK != (res = cbor_utils_EncodeBreak(octaveFormatter->buffer + encodedBytes,
+                                                   &remaining, &encodedBytes)))
+        {
+            goto cborerror;
+        }
+        LE_INFO("1st pass done Total: %zu", encodedBytes);
+        LE_DUMP(octaveFormatter->buffer, encodedBytes);
+        formatter->scan = true;
+        formatter->filter = SNAPSHOT_FILTER_NORMAL;
+    }
+    // diff tree 2nd pass end (modified nodes): close nodes map and move on to deleted nodes
+    else if (SNAPSHOT_FILTER_NORMAL == (formatter->filter & LIVE_FILTERS))
+    {
+        LE_INFO("2nd pass  Total: %zu", encodedBytes);
+        LE_DUMP(octaveFormatter->buffer, encodedBytes);
+        if (LE_OK != (res = cbor_utils_EncodeBreak(octaveFormatter->buffer + encodedBytes,
+                                                   &remaining, &encodedBytes)))
+        {
+            goto cborerror;
+        }
+        LE_INFO("2nd pass  Total: %zu", encodedBytes);
+        LE_DUMP(octaveFormatter->buffer, encodedBytes);
+        formatter->scan = true;
+        formatter->filter = SNAPSHOT_FILTER_DELETED;
+    }
+    // diff tree 3rd pass end (deleted nodes): close nodes array
+    else if (SNAPSHOT_FILTER_DELETED == (formatter->filter & ALL_FILTERS))
+    {
+        LE_INFO("3rd pass  Total: %zu", encodedBytes);
+        LE_DUMP(octaveFormatter->buffer, encodedBytes);
+        formatter->scan = false;
+        if (LE_OK != (res = cbor_utils_EncodeBreak(octaveFormatter->buffer + encodedBytes,
+                                                   &remaining, &encodedBytes)))
+        {
+            goto cborerror;
+        }
+        LE_INFO("3rd pass  Total: %zu", encodedBytes);
+        LE_DUMP(octaveFormatter->buffer, encodedBytes);
+    }
+    else
+    {
+        LE_FATAL("Unexpected filter requested");
+    }
+    octaveFormatter->encodedBytes = encodedBytes;
+    octaveFormatter->remaining = remaining;
+    SendOrAdvance(octaveFormatter, !formatter->scan); // force sending if no more pass to perform
+    return;
+
+cborerror:
+    LE_ERROR("Failed to encode data with error %s", LE_RESULT_TXT(res));
+    snapshot_End(res);
+}
+
+//--------------------------------------------------------------------------------------------------
+/*
+ * Close and clean up the formatter instance.
+ */
+//--------------------------------------------------------------------------------------------------
+static void Close
+(
+    snapshot_Formatter_t *formatter ///< Formatter instance.
+)
+{
+    OctaveFormatter_t *octaveFormatter = CONTAINER_OF(formatter, OctaveFormatter_t, base);
+
+    LE_DEBUG("Closing formatter");
+    le_fdMonitor_Delete(octaveFormatter->monitor);
+}
+
+//--------------------------------------------------------------------------------------------------
+/*
+ * Simple wrapper to step the greater state machine.
+ */
+//--------------------------------------------------------------------------------------------------
+static void SnapshotStep
+(
+    OctaveFormatter_t *octaveFormatter  ///< Formatter instance.
+)
+{
+    LE_UNUSED(octaveFormatter);
+
+    LE_DEBUG("Stepping snapshot state machine");
+    snapshot_Step();
+}
+
+//--------------------------------------------------------------------------------------------------
+/*
+ * Transition the formatter state machine to the next state.
+ */
+//--------------------------------------------------------------------------------------------------
+static void Step
+(
+    OctaveFormatter_t *octaveFormatter  ///< Formatter instance.
+)
+{
+    static const OctaveFormatterStep_t steps[STATE_MAX - 1] =
+    {
+        &SnapshotStep,          // STATE_SNAPSHOT_STEP
+        &NodeName,              // STATE_NODE_NAME
+        &NodeOpen,              // STATE_NODE_OPEN
+        &NodeValues,            // STATE_NODE_VALUES
+        &NodeValueBody,         // STATE_NODE_VALUE_BODY
+        &NodeDefaultValue,      // STATE_NODE_DEFAULT
+        &NodeDefaultValueBody,  // STATE_NODE_DEFAULT_BODY
+        &NodeJsonExample,       // STATE_JSON_EX
+        &NodeJsonExampleBody    // STATE_JSON_EX_BODY
+    };
+#if LE_DEBUG_ENABLED
+    const char *stepNames[STATE_MAX - 1] =
+    {
+        "STATE_SNAPSHOT_STEP",
+        "STATE_NODE_NAME",
+        "STATE_NODE_OPEN",
+        "STATE_NODE_VALUES",
+        "STATE_NODE_VALUE_BODY",
+        "STATE_NODE_DEFAULT",
+        "STATE_NODE_DEFAULT_BODY",
+        "STATE_NODE_JSON_EX",
+        "STATE_NODE_JSON_EX_BODY"
+    };
+#endif /* end LE_DEBUG_ENABLED */
+
+    if (octaveFormatter->nextState == STATE_START)
+    {
+        // If things haven't started yet, just wait until they do.
+        return;
+    }
+
+    LE_ASSERT(octaveFormatter->nextState > STATE_START && octaveFormatter->nextState < STATE_MAX);
+#if LE_DEBUG_ENABLED
+    LE_DEBUG("Octave formatter transition: -> %s", stepNames[octaveFormatter->nextState - 1]);
+#endif /* end LE_DEBUG_ENABLED */
+    steps[octaveFormatter->nextState - 1](octaveFormatter);
+}
+
+//--------------------------------------------------------------------------------------------------
+/*
+ * Initialise and return the Octave CBOR snapshot formatter instance.
+ *
+ * @return LE_OK on success, otherwise an appropriate error code.
+ */
+//--------------------------------------------------------------------------------------------------
+LE_SHARED le_result_t GetOctaveSnapshotFormatter
+(
+    uint32_t                      flags,    ///< [IN]  Flags that were passed to the snapshot
+                                            ///<       request.
+    int                           stream,   ///< [IN]  File descriptor to write formatted output to.
+    struct snapshot_Formatter   **formatter ///< [OUT] Returned formatter instance.
+)
+{
+    static OctaveFormatter_t octaveFormatter =
+    {
+        {
+            .startTree  = &StartTree,
+            .beginNode  = &BeginNode,
+            .endNode    = &EndObject,
+            .endTree    = &EndTree,
+            .close      = &Close
+        }
+    };
+
+    LE_ASSERT(formatter != NULL);
+    *formatter = &octaveFormatter.base;
+
+    memset(octaveFormatter.buffer, 0, sizeof(octaveFormatter.buffer));
+    octaveFormatter.remaining     = sizeof(octaveFormatter.buffer);
+    octaveFormatter.encodedBytes  = 0;
+    octaveFormatter.next          = 0;
+    octaveFormatter.available     = 0;
+    octaveFormatter.isFullDump    = (flags & OCTAVE_FLAG_FULL_TREE);
+    octaveFormatter.skipNode      = true;
+    octaveFormatter.nextState     = STATE_START;
+
+    if (octaveFormatter.isFullDump)
+    {
+        octaveFormatter.base.filter   = LIVE_FILTERS;
+        LE_DEBUG("Octave formatter: full tree. Transition to STATE_START");
+    }
+    else
+    {
+        octaveFormatter.base.filter   = SNAPSHOT_FILTER_CREATED;
+        LE_DEBUG("Octave formatter: diff tree. Transition to STATE_START");
+    }
+    octaveFormatter.base.scan     = true;
+
+    // Configure event handler for outputting formatted data.
+    octaveFormatter.monitor = le_fdMonitor_Create(
+                                "OctaveSnapshotStream",
+                                stream,
+                                &StreamHandler,
+                                POLLOUT
+                            );
+    le_fdMonitor_SetContextPtr(octaveFormatter.monitor, &octaveFormatter);
+    le_fdMonitor_Disable(octaveFormatter.monitor, POLLOUT);
+
+    return LE_OK;
+}
+
+/// Component initialisation.
+COMPONENT_INIT
+{
+    // Do nothing.
+}

--- a/components/octaveFormatter/octaveFormatter.h
+++ b/components/octaveFormatter/octaveFormatter.h
@@ -1,0 +1,35 @@
+
+//--------------------------------------------------------------------------------------------------
+/**
+ * @file octaveFormatter.h
+ *
+ * Plugin interface for Octave CBOR snapshot formatter.
+ *
+ * Copyright (C) Sierra Wireless Inc.
+ */
+//--------------------------------------------------------------------------------------------------
+
+#ifndef OCTAVEFORMATTER_H_INCLUDE_GUARD
+#define OCTAVEFORMATTER_H_INCLUDE_GUARD
+
+#include "legato.h"
+
+// Forward reference.
+struct snapshot_Formatter;
+
+//--------------------------------------------------------------------------------------------------
+/*
+ * Initialise and return the Octave CBOR snapshot formatter instance.
+ *
+ * @return LE_OK on success, otherwise an appropriate error code.
+ */
+//--------------------------------------------------------------------------------------------------
+LE_SHARED le_result_t GetOctaveSnapshotFormatter
+(
+    uint32_t                      flags,    ///< [IN]  Flags that were passed to the snapshot
+                                            ///<       request.
+    int                           stream,   ///< [IN]  File descriptor to write formatted output to.
+    struct snapshot_Formatter   **formatter ///< [OUT] Returned formatter instance.
+);
+
+#endif /* end OCTAVEFORMATTER_H_INCLUDE_GUARD */

--- a/dataHub.adef
+++ b/dataHub.adef
@@ -21,6 +21,8 @@ executables:
 {
     hubd = ( components/dataHub )
     dhub = ( components/adminTool )
+    // Datahub snapshot test tool
+//    dsnap = ( test/snapshot )
 }
 
 processes:
@@ -51,4 +53,6 @@ bindings:
     dhub.adminTool.query -> hubd.dataHub.query
     dhub.adminTool.io -> hubd.dataHub.io
     hubd.dataHub.le_appInfo -> <root>.le_appInfo
+    // Datahub snapshot test tool
+//    dsnap.snapshot.query -> hubd.dataHub.query
 }

--- a/query.api
+++ b/query.api
@@ -667,7 +667,7 @@ DEFINE BEGINNING_OF_TIME = 0;
 /*
  * Capture a snapshot of the resource tree.
  *
- * The snapshot will be of the portion of the tree rooted at the given pathe, and include all values
+ * The snapshot will be of the portion of the tree rooted at the given path, and include all values
  * which have changed since the provided time stamp.  The response will be encoded according to the
  * specified formatter and streamed back to the requester via the provided file handle.  The end of
  * data or an error will be indicated by invoking the provided callback with a result code.
@@ -701,13 +701,13 @@ FUNCTION TakeSnapshot
 /*
  * Control whether deletion records should be maintained within the Data Hub.
  *
- * Turning on deletion tracking will cause a small amount of metadata to be retained for each
- * deleted resource.  This metadata will be supplied to the formatter when a snapshot is requested
- * so that nodes which have disappeared from the tree can be recorded appropriately.  Because this
- * metadata will gradually accumulate over time as nodes are removed, there are two ways of
- * requesting that the deletion data be flushed.  The first is to just disable and then reenable
- * tracking using this function.  The second is to pass the SNAPSHOT_FLAG_FLUSH_DELETIONS flag when
- * requesting a snapshot.
+ * Turning on deletion tracking will cause some metadata to be retained for each deleted resource.
+ * This metadata will be supplied to the formatter when a snapshot is requested so that nodes which
+ * have disappeared from the tree can be recorded appropriately.  Because this metadata will
+ * gradually accumulate over time as nodes are removed, there are two ways of requesting that the
+ * deletion data be flushed.  The first is to just disable and then reenable tracking using this
+ * function.  The second is to pass the SNAPSHOT_FLAG_FLUSH_DELETIONS flag when requesting a
+ * snapshot.
  */
 //--------------------------------------------------------------------------------------------------
 FUNCTION TrackDeletions

--- a/query.api
+++ b/query.api
@@ -7,9 +7,10 @@
  * The Data Hub Query API provides its clients with the ability to query resources within the
  * Data Hub's resource tree.
  *
- * There are two types of query supported:
+ * There are three types of query supported:
  * - Fetching of values
  * - Statistical analysis of buffered data sets
+ * - Fetching of versioned snapshots of all or part of the resource tree.
  *
  *
  * @section c_dataHubQuery_Fetching Fetching Data
@@ -71,6 +72,15 @@
  * - query_RemoveStringPushHandler()
  * - query_RemoveJsonPushHandler()
  *
+ *
+ * @section c_dataHubQuery_Snapshots Resource Tree Snapshots
+ *
+ * The snapshot API provides a mechanism to get the state of the resource tree at a given point in
+ * time.  The entire resource tree may be requested, or only a particular branch, and all values may
+ * be requested or only those that have changed since a certain point in time.  The API consists of
+ * two functions:
+ * - query_TakeSnapshot()
+ * - query_TrackDeletions()
  *
  * Copyright (C) Sierra Wireless Inc.
  *
@@ -610,4 +620,97 @@ EVENT JsonPush
 (
     string path[io.MAX_RESOURCE_PATH_LEN] IN,///< Absolute path of resource.
     JsonPushHandler callback
+);
+
+//--------------------------------------------------------------------------------------------------
+/*
+ * Supported snapshot encoding formats.
+ */
+//--------------------------------------------------------------------------------------------------
+ENUM SnapshotFormat
+{
+    SNAPSHOT_FORMAT_JSON,   ///< Basic JSON representation of the resource tree.
+    SNAPSHOT_FORMAT_OCTAVE, ///< Format for the payload of an Octave "tree" or "tree-diff" message.
+    SNAPSHOT_FORMAT_CUSTOM  ///< First available custom format type value.
+};
+
+//--------------------------------------------------------------------------------------------------
+/*
+ * Snapshot control flags.
+ */
+//--------------------------------------------------------------------------------------------------
+BITMASK SnapshotFlag
+{
+    SNAPSHOT_FLAG_FLUSH_DELETIONS,  ///< After taking this snapshot, flush accumulated deletion
+                                    ///< records.
+    SNAPSHOT_FLAG_CUSTOM            ///< First available custom control flag.
+};
+
+//--------------------------------------------------------------------------------------------------
+/*
+ * Callback to be invoked when the encoded stream is complete or if an error occurs.
+ */
+//--------------------------------------------------------------------------------------------------
+HANDLER HandleSnapshotResult
+(
+    le_result_t status IN ///< LE_OK when content is complete. Any other value indicates an error.
+);
+
+//--------------------------------------------------------------------------------------------------
+/*
+ * Beginning of time.  Used to indicate a request for all tree content since the tree was created.
+ */
+//--------------------------------------------------------------------------------------------------
+DEFINE BEGINNING_OF_TIME = 0;
+
+//--------------------------------------------------------------------------------------------------
+/*
+ * Capture a snapshot of the resource tree.
+ *
+ * The snapshot will be of the portion of the tree rooted at the given pathe, and include all values
+ * which have changed since the provided time stamp.  The response will be encoded according to the
+ * specified formatter and streamed back to the requester via the provided file handle.  The end of
+ * data or an error will be indicated by invoking the provided callback with a result code.
+ *
+ * If deletions are being tracked (@see TrackDeletions), then information about deleted resources
+ * will be included in the snapshot if the formatter includes it.  The SNAPSHOT_FLAG_FLUSH_DELETIONS
+ * flag may be passed to flush and reset the current deletion tracking as part of the snapshot
+ * operation.  Doing this would mean that deletion information would only be available back to the
+ * timestamp of the last snapshot.
+ */
+//--------------------------------------------------------------------------------------------------
+FUNCTION TakeSnapshot
+(
+    uint32                  format                          IN, ///< Snapshot output data format.
+    SnapshotFlag            flags                           IN, ///< Flags controlling the
+                                                                ///< snapshot action.
+    string                  path[io.MAX_RESOURCE_PATH_LEN]  IN, ///< Tree path to use as the root.
+    double                  since                           IN, ///< Request only values that have
+                                                                ///< changed since this time (in s).
+                                                                ///< Use BEGINNING_OF_TIME to
+                                                                ///< request the full tree.
+    HandleSnapshotResult    callback                        IN, ///< Completion callback to indicate
+                                                                ///< the end of the streamed
+                                                                ///< snapshot, or an error.
+    file                    snapshotStream                  OUT ///< File descriptor to which the
+                                                                ///< encoded snapshot data will be
+                                                                ///< streamed.
+);
+
+//--------------------------------------------------------------------------------------------------
+/*
+ * Control whether deletion records should be maintained within the Data Hub.
+ *
+ * Turning on deletion tracking will cause a small amount of metadata to be retained for each
+ * deleted resource.  This metadata will be supplied to the formatter when a snapshot is requested
+ * so that nodes which have disappeared from the tree can be recorded appropriately.  Because this
+ * metadata will gradually accumulate over time as nodes are removed, there are two ways of
+ * requesting that the deletion data be flushed.  The first is to just disable and then reenable
+ * tracking using this function.  The second is to pass the SNAPSHOT_FLAG_FLUSH_DELETIONS flag when
+ * requesting a snapshot.
+ */
+//--------------------------------------------------------------------------------------------------
+FUNCTION TrackDeletions
+(
+    bool on IN ///< If true, start tracking deletions; if false stop tracking and flush records.
 );

--- a/test/actuator/actuator.c
+++ b/test/actuator/actuator.c
@@ -1,8 +1,17 @@
 #include "legato.h"
 #include "interfaces.h"
 
+// Test has apparently been broken for a while, but due to a binding error the app never actually
+// started up enough to run and discover this.
+// TODO: Fix and re-enable this test.
+#define ENABLE_DUMMY_ACTUATOR_TEST 0
+
 #define COUNTER_NAME "counter/value"
 
+#define EPHEMERAL_A_NAME "ephemeral1/value"
+#define EPHEMERAL_B_NAME "ephemeral2/value"
+
+#if ENABLE_DUMMY_ACTUATOR_TEST
 
 // Here we track how many times the TreeChangeHandler callback
 // has been called for each path / type / operation
@@ -166,7 +175,10 @@ void AssertTimer
     admin_RemoveResourceTreeChangeHandler(treeChangeHandlerRef);
 }
 
-COMPONENT_INIT
+static void PrepDummyActuatorTest
+(
+    void
+)
 {
     le_result_t result;
 
@@ -219,4 +231,65 @@ COMPONENT_INIT
 
     le_timer_SetMsInterval(assertionTimer,2000);
     le_timer_Start(assertionTimer);
+}
+
+#endif /* end ENABLE_DUMMY_ACTUATOR_TEST */
+
+void LifecycleTimer
+(
+    le_timer_Ref_t timerRef
+)
+{
+    double              timestamp;
+    le_result_t         result;
+    static unsigned int count = 0;
+
+    LE_UNUSED(timerRef);
+
+    ++count;
+    LE_INFO("Cycling resource lives (%u)", count);
+
+    if (count % 2 == 0)
+    {
+        if (io_GetTimestamp(EPHEMERAL_A_NAME, &timestamp) == LE_NOT_FOUND)
+        {
+            result = io_CreateOutput(EPHEMERAL_A_NAME, IO_DATA_TYPE_BOOLEAN, "");
+            LE_ASSERT(result == LE_OK);
+            io_PushBoolean(EPHEMERAL_A_NAME, IO_NOW, true);
+        }
+        else
+        {
+            io_DeleteResource(EPHEMERAL_A_NAME);
+        }
+    }
+    else if (count % 3 == 0)
+    {
+        if (io_GetTimestamp(EPHEMERAL_B_NAME, &timestamp) == LE_NOT_FOUND)
+        {
+            result = io_CreateOutput(EPHEMERAL_B_NAME, IO_DATA_TYPE_BOOLEAN, "");
+            LE_ASSERT(result == LE_OK);
+            io_PushBoolean(EPHEMERAL_B_NAME, IO_NOW, false);
+        }
+        else
+        {
+            io_DeleteResource(EPHEMERAL_B_NAME);
+        }
+    }
+}
+
+COMPONENT_INIT
+{
+    LE_INFO("Starting actuator...");
+
+#if ENABLE_DUMMY_ACTUATOR_TEST
+    PrepDummyActuatorTest();
+#endif /* end ENABLE_DUMMY_ACTUATOR_TEST */
+
+    // Create timer to periodically add and remove resources, for deletion tracking.
+    le_timer_Ref_t lifecycleTimer = le_timer_Create("Add/Remove Timer");
+    le_timer_SetHandler(lifecycleTimer, &LifecycleTimer);
+
+    le_timer_SetMsInterval(lifecycleTimer, 10000);
+    le_timer_SetRepeat(lifecycleTimer, 0);
+    le_timer_Start(lifecycleTimer);
 }

--- a/test/gdbhub
+++ b/test/gdbhub
@@ -1,0 +1,45 @@
+#!/bin/bash
+
+DHUB=_build_dataHub/localhost/app/dataHub/staging/read-only/bin/dhub
+
+startlegato
+sdir bind "<${USER}>.le_appInfo" "<${USER}>.le_appInfo"
+sdir bind "<${USER}>.sensord.sensor.io" "<${USER}>.io"
+sdir bind "<${USER}>.sensord.periodicSensor.dhubIO" "<${USER}>.io"
+sdir bind "<${USER}>.actuatord.actuator.io" "<${USER}>.io"
+sdir bind "<${USER}>.actuatord.actuator.admin" "<${USER}>.admin"
+sdir bind "<${USER}>.dhubToolAdmin" "<${USER}>.admin"
+sdir bind "<${USER}>.dhubToolIo" "<${USER}>.io"
+sdir bind "<${USER}>.dhubToolQuery" "<${USER}>.query"
+sdir bind "<${USER}>.dsnap.snapshot.query" "<${USER}>.query"
+
+tmux new -d "gdb -ex 'set debug-file-directory ${LEGATO_ROOT}/build/localhost/debug' \
+            -ex r _build_dataHub/localhost/app/dataHub/staging/read-only/bin/hubd"
+
+sleep 5
+
+_build_sensor/localhost/app/sensor/staging/read-only/bin/sensord &
+SENSORPID=$!
+echo "Started sensor app with PID $SENSORPID."
+
+_build_actuator/localhost/app/actuator/staging/read-only/bin/actuatord &
+ACTUATORPID=$!
+echo "Started actuator app with PID $ACTUATORPID."
+
+_build_appInfoStub/localhost/app/appInfoStub/staging/read-only/bin/appInfoD \
+    --sensor=$SENSORPID                                                     \
+    --actuator=$ACTUATORPID &
+
+sleep 0.25
+
+${DHUB} set backupPeriod temp 5
+${DHUB} set bufferSize temp 100
+${DHUB} set default /app/sensor/counter/period 0.25
+${DHUB} set source /app/sensor/temperature/trigger /app/sensor/counter/value
+${DHUB} set source /obs/temp /app/sensor/temperature/value
+${DHUB} set default /app/sensor/counter/enable true
+
+sleep 1
+
+log level DEBUG hubd/dataHub
+log level DEBUG hubd/jsonFormatter

--- a/test/snapshot.adef
+++ b/test/snapshot.adef
@@ -1,0 +1,24 @@
+//--------------------------------------------------------------------------------------------------
+/**
+ * Data Hub snapshot API testing tool.  Provides a command-line interface to the snapshot API.
+ *
+ * Copyright (C) Sierra Wireless Inc.
+ */
+//--------------------------------------------------------------------------------------------------
+
+executables:
+{
+    dsnap = ( snapshot )
+}
+
+#if ${LE_CONFIG_LINUX} = y
+bindings:
+{
+    dsnap.snapshot.query -> dataHub.query
+}
+#else /* !LE_CONFIG_LINUX */
+extern:
+{
+    dsnap.snapshot.query
+}
+#endif /* end !LE_CONFIG_LINUX */

--- a/test/snapshot/Component.cdef
+++ b/test/snapshot/Component.cdef
@@ -1,0 +1,12 @@
+requires:
+{
+    api:
+    {
+        query.api [manual-start]
+    }
+}
+
+sources:
+{
+    snapshotTool.c
+}

--- a/test/snapshot/Component.cdef
+++ b/test/snapshot/Component.cdef
@@ -10,3 +10,10 @@ sources:
 {
     snapshotTool.c
 }
+
+cflags:
+{
+#if ${MK_CONFIG_ENABLE_OCTAVE} = y
+    -DWITH_OCTAVE
+#endif
+}

--- a/test/snapshot/snapshotTool.c
+++ b/test/snapshot/snapshotTool.c
@@ -1,0 +1,269 @@
+//--------------------------------------------------------------------------------------------------
+/**
+ * Test application to call the snapshot API and output the resulting formatted data.
+ *
+ * Copyright (C) Sierra Wireless Inc.
+ */
+//--------------------------------------------------------------------------------------------------
+#include "legato.h"
+#include "interfaces.h"
+
+/// FD monitor for the incoming snapshot data FD.
+static le_fdMonitor_Ref_t MonitorRef;
+
+/// FD to write the formatted output to.
+static int OutFile;
+
+/// Query API connection state.
+static bool Connected;
+
+//--------------------------------------------------------------------------------------------------
+/**
+ * Terminate the application.
+ */
+//--------------------------------------------------------------------------------------------------
+static void DoExit
+(
+    int ret ///< Return code.
+)
+{
+    if (Connected)
+    {
+        query_DisconnectService();
+    }
+
+#if LE_CONFIG_RTOS
+    le_thread_Exit((void *) ret);
+#else
+    exit(ret);
+#endif
+}
+
+//--------------------------------------------------------------------------------------------------
+/**
+ * Handle completion result of snapshot operation.
+ */
+//--------------------------------------------------------------------------------------------------
+static void HandleResult
+(
+    le_result_t  result,    ///< Snapshot operation result.
+    void        *context    ///< Unused.
+)
+{
+    int fd = -1;
+    int ret = EXIT_SUCCESS;
+
+    LE_UNUSED(context);
+
+    LE_DEBUG("Got result: %s", LE_RESULT_TXT(result));
+
+    // Clean up FDs and monitor.
+    if (MonitorRef != NULL)
+    {
+        fd = le_fdMonitor_GetFd(MonitorRef);
+        le_fdMonitor_Delete(MonitorRef);
+        MonitorRef = NULL;
+    }
+    if (fd >= 0)
+    {
+        le_fd_Close(fd);
+    }
+    if (OutFile != STDOUT_FILENO && OutFile >= 0)
+    {
+        le_fd_Close(OutFile);
+    }
+
+    // Handle result.
+    switch (result)
+    {
+        case LE_OK:
+            LE_INFO("Snapshot operation completed successfully.");
+            break;
+        case LE_BUSY:
+            LE_WARN("Another snapshot operation is currently in progress, cancelling request.");
+            break;
+        default:
+            LE_ERROR("Snapshot failed with result %s", LE_RESULT_TXT(result));
+            ret = EXIT_FAILURE;
+            break;
+    }
+
+    DoExit(ret);
+}
+
+//--------------------------------------------------------------------------------------------------
+/**
+ * Handle formatted snapshot data being streamed back from the Data Hub.
+ */
+//--------------------------------------------------------------------------------------------------
+static void HandleStreamData
+(
+    int   fd,       ///< FD by which the formatted data is streamed.
+    short events    ///< Event bitfield which triggered this callback.
+)
+{
+    size_t  offset;
+    ssize_t count;
+    ssize_t written;
+    uint8_t buffer[128];
+
+    if (events & POLLIN)
+    {
+        // For the purposes of this tool we will just copy the input to the output in a straight
+        // forward blocking manner.  In a real system you would probably want to handle POLLOUT on
+        // the output and only feed it when it was ready.
+        for (;;)
+        {
+            count = le_fd_Read(fd, buffer, sizeof(buffer));
+            if (count < 0)
+            {
+                if (errno != EAGAIN)
+                {
+                    LE_WARN("Format stream read error: %d", errno);
+                }
+                return;
+            }
+            else if (count > 0)
+            {
+                offset = 0;
+                while (count > 0)
+                {
+                    written = le_fd_Write(OutFile, &buffer[offset], count);
+                    if (written < 0)
+                    {
+                        LE_WARN("Output stream write error");
+                        return;
+                    }
+                    else
+                    {
+                        count -= written;
+                        offset += written;
+                        LE_ASSERT(count >= 0);
+                    }
+                }
+            }
+            else
+            {
+                break;
+            }
+        }
+    }
+}
+
+//--------------------------------------------------------------------------------------------------
+/**
+ * Print help text to stdout and exit.
+ */
+//--------------------------------------------------------------------------------------------------
+static void HandleHelpRequest
+(
+    void
+)
+{
+    puts(
+        "Usage: dsnap [-h] [-f <format>] [-s <since>] [-p <path>]"
+#if LE_CONFIG_FILESYSTEM
+        " [-o <output>]"
+#endif
+    );
+
+    puts(
+        "\n"
+        "    -h, --help              Display this help.\n"
+        "    -f, --format=<string>   Set output format to <string> (only \"json\" so far).\n"
+        "    -s, --since=<number>    Only output information for records that have changed since\n"
+        "                            <number> seconds from the Epoch.  Default (no limit) is 0.\n"
+        "    -p, --path=<string>     Only consider the tree at and beneath the path <string>.\n"
+        "                            The default is \"/\" for the full tree.\n"
+#if LE_CONFIG_FILESYSTEM
+        "    -o, --output=<string>   File path to write the output to.  Default is to write to\n"
+        "                            stdout.\n"
+#endif /* end LE_CONFIG_FILESYSTEM */
+    );
+
+    DoExit(EXIT_SUCCESS);
+}
+
+//--------------------------------------------------------------------------------------------------
+/**
+ * Component initialisation.  Handle the tool's command line parameters.
+ */
+//--------------------------------------------------------------------------------------------------
+COMPONENT_INIT
+{
+    char        *endPtr = NULL;
+    const char  *formatStr = "json";
+    const char  *outputStr = NULL;
+    const char  *pathStr = "/";
+    const char  *sinceStr = "0";
+    double       since;
+    int          formatStream = -1;
+    le_result_t  result;
+    uint32_t     flags = 0;
+    uint32_t     format;
+
+    LE_ASSERT(MonitorRef == NULL);
+    Connected = false;
+
+    // Collect arguments.
+    le_arg_SetFlagCallback(&HandleHelpRequest, "h", "help");
+    le_arg_SetStringVar(&formatStr, "f", "format");
+    le_arg_SetStringVar(&sinceStr, "s", "since");
+    le_arg_SetStringVar(&pathStr, "p", "path");
+#if LE_CONFIG_FILESYSTEM
+    le_arg_SetStringVar(&outputStr, "o", "output");
+#endif
+
+    le_arg_Scan();
+    result = le_arg_GetScanResult();
+    if (result != LE_OK)
+    {
+        LE_ERROR("Argument parsing failed with code %s", LE_RESULT_TXT(result));
+        DoExit(EXIT_FAILURE);
+    }
+
+    if (strcmp(formatStr, "json") == 0)
+    {
+        format = QUERY_SNAPSHOT_FORMAT_JSON;
+    }
+    else
+    {
+        LE_ERROR("Unknown format: %s", formatStr);
+        DoExit(EXIT_FAILURE);
+    }
+
+    since = strtod(sinceStr, &endPtr);
+    if (endPtr == sinceStr)
+    {
+        LE_ERROR("Invalid time stamp: %s", sinceStr);
+        DoExit(EXIT_FAILURE);
+    }
+
+    if (outputStr == NULL)
+    {
+        OutFile = STDOUT_FILENO;
+    }
+    else
+    {
+        OutFile = le_fd_Open(outputStr, O_WRONLY | O_CREAT | O_TRUNC,
+            S_IRUSR | S_IWUSR | S_IRGRP | S_IWGRP | S_IROTH | S_IWOTH);
+    }
+    LE_ASSERT(OutFile >= 0);
+
+    // Connect to the Data Hub.
+    result = query_TryConnectService();
+    if (result != LE_OK)
+    {
+        LE_ERROR("Got %s while connecting to Data Hub Query API", LE_RESULT_TXT(result));
+        DoExit(EXIT_FAILURE);
+    }
+    Connected = true;
+
+    // Initiate the snapshot.
+    query_TakeSnapshot(format, flags, pathStr, since, &HandleResult, NULL, &formatStream);
+    if (formatStream >= 0)
+    {
+        // Watch for formatted data to be streamed back.
+        MonitorRef = le_fdMonitor_Create("SnapshotStream", formatStream, &HandleStreamData, POLLIN);
+    }
+}


### PR DESCRIPTION
This PR pulls in support for the snapshot API from the Legato Datahub

BROOKLYN-3546

The octaveFormatter component is currently under review in LE-14969
https://gerrit-legato/c/Legato/Service/DataHub/+/69832
Once LE-14969 is approved, this change should be committed.

Adding this functionality does not break the existing tree diff method but this change must be committed before BROOKLYN-3379, which is to update the cloud interface to use the snapshot method.

Testing:
Verified as part of BROOKLYN-3379
