### PR TITLE
Add admin create and delete resource API functions

### DIFF
--- a/components/dataHub/adminService.c
+++ b/components/dataHub/adminService.c
@@ -2224,9 +2224,27 @@ void admin_EndUpdate
     res_EndUpdate();
 }
 
-static le_result_t ExtractAppNameFromAbsolutePath(const char* path, char* appName, size_t appNameSize)
+//--------------------------------------------------------------------------------------------------
+/**
+ * Extract the application name from an absolute path.
+ * eg. "/app/foo/sensor/value" => "foo"
+ *
+ * @return
+ *  - LE_OK if successful.
+ *  - LE_BAD_PARAMETER if the path is not absolute.
+ *  - LE_OVERFLOW if appName buffer is not large enough to contain the application name.
+ */
+//--------------------------------------------------------------------------------------------------
+static le_result_t ExtractAppNameFromAbsolutePath
+(
+    const char* path,
+        ///< [IN] Absolute resource tree path.
+    char* appName,
+        ///< [OUT] The extracted application name.
+    size_t appNameSize
+        ///< [IN] Size of the appName buffer.
+)
 {
-
     // Verify the path is absolute
     if (strncmp(path, "/app/", strlen("/app/")))
     {
@@ -2514,11 +2532,11 @@ void admin_MarkOptional
     resTree_EntryRef_t resRef = resTree_FindEntryAtAbsolutePath(path);
     if (resRef == NULL)
     {
-        LE_KILL_CLIENT("Attempt to mark non-existent resource optional at '%s'.", path);
+        LE_ERROR("Attempt to mark non-existent resource optional at '%s'.", path);
     }
     else if (resTree_GetEntryType(resRef) != ADMIN_ENTRY_TYPE_OUTPUT)
     {
-        LE_KILL_CLIENT("Attempt to mark non-Output resource optional at '%s'.", path);
+        LE_ERROR("Attempt to mark non-Output resource optional at '%s'.", path);
     }
     else
     {

--- a/components/dataHub/adminService.c
+++ b/components/dataHub/adminService.c
@@ -2223,3 +2223,305 @@ void admin_EndUpdate
 
     res_EndUpdate();
 }
+
+static le_result_t ExtractAppNameFromAbsolutePath(const char* path, char* appName, size_t appNameSize)
+{
+
+    // Verify the path is absolute
+    if (strncmp(path, "/app/", strlen("/app/")))
+    {
+        LE_ERROR("Path '%s' is not absolute.", path);
+        return LE_BAD_PARAMETER;
+    }
+
+    // Skip "/app/"
+    size_t i = 5; // Index into path.
+
+    // Look for next slash
+    const char* terminatorPtr = strchrnul(path + i, '/');
+
+    // Compute the length of the entry name in this path element.
+    size_t nameLen = terminatorPtr - (path + i);
+
+    // Sanity check the length.
+    if (nameLen == 0)
+    {
+        LE_ERROR("Resource path element missing in path '%s'.", path);
+        return LE_BAD_PARAMETER;
+    }
+    if (nameLen >= appNameSize)
+    {
+        LE_ERROR("Resource path element too long in path '%s'.", path);
+        return LE_OVERFLOW;
+    }
+
+    // Copy the name out and null terminate it.
+    (void)strncpy(appName, path + i, nameLen);
+    appName[nameLen] = '\0';
+
+    return LE_OK;
+}
+
+//--------------------------------------------------------------------------------------------------
+/**
+ * Create an input resource, which is used to push data into the Data Hub.
+ *
+ * Does nothing if the resource already exists.
+ *
+ * @return
+ *  - LE_OK if successful.
+ *  - LE_DUPLICATE if a resource by that name exists but with different direction, type or units.
+ *  - LE_NO_MEMORY if the client is not permitted to create that many resources.
+ *  - LE_FAULT if the path is not absolute.
+ */
+//--------------------------------------------------------------------------------------------------
+le_result_t admin_CreateInput
+(
+    const char* path,
+        ///< [IN] Absolute resource tree path.
+    io_DataType_t dataType,
+        ///< [IN] The data type.
+    const char* LE_NONNULL units
+        ///< [IN] e.g., "degC" (see senml); "" = unspecified.
+)
+{
+    LE_DEBUG("'%s' <%s> '%s'.", path, hub_GetDataTypeName(dataType), units);
+
+    resTree_EntryRef_t resRef = resTree_FindEntryAtAbsolutePath(path);
+
+    // Check for another resource having the same name in the same namespace.
+    if (resRef != NULL)
+    {
+        switch (resTree_GetEntryType(resRef))
+        {
+            case ADMIN_ENTRY_TYPE_INPUT:
+
+                // Check data type and units to see if they match.
+                if (   (resTree_GetDataType(resRef) != dataType)
+                    || (strcmp(units, resTree_GetUnits(resRef)) != 0))
+                {
+                    return LE_DUPLICATE;
+                }
+
+                // The object already exists.  Nothing more needs to be done.
+                return LE_OK;
+
+            case ADMIN_ENTRY_TYPE_OUTPUT:
+            case ADMIN_ENTRY_TYPE_OBSERVATION:
+
+                // These conflict.
+                return LE_DUPLICATE;
+
+            case ADMIN_ENTRY_TYPE_NAMESPACE:
+            case ADMIN_ENTRY_TYPE_PLACEHOLDER:
+
+                // These can be upgraded to Input objects by resTree_GetInput().
+                break;
+
+            case ADMIN_ENTRY_TYPE_NONE:
+
+                LE_FATAL("Unexpected entry type.");
+        }
+    }
+
+    // Get the "/app" namespace first.
+    resTree_EntryRef_t nsRef = resTree_GetEntry(resTree_GetRoot(), "app");
+
+    // Extract the app name from absolute path.
+    char appName[HUB_MAX_ENTRY_NAME_BYTES];
+    if (LE_OK != ExtractAppNameFromAbsolutePath(path, appName, sizeof(appName)))
+    {
+        LE_ERROR("Failed to extract app name from abs path '%s'.", path);
+        return LE_FAULT;
+    }
+
+    LE_DEBUG("App name is '%s'.", appName);
+
+    // Now get the app's namespace under the /app namespace.
+    nsRef = resTree_GetEntry(nsRef, appName);
+
+    // Create the Input resource. Need to convert absolute path to relative one.
+    resRef = resTree_GetInput(nsRef, path + strlen("/app/") + strlen(appName) + strlen("/"), dataType, units);
+    if (resRef == NULL)
+    {
+        LE_ERROR("Failed to create Input '/app/%s/%s'.", resTree_GetEntryName(nsRef), path);
+        return LE_FAULT;
+    }
+
+    return LE_OK;
+}
+
+//--------------------------------------------------------------------------------------------------
+/**
+ * Create an output resource, which is used to receive data output from the Data Hub.
+ *
+ * Does nothing if the resource already exists.
+ *
+ * @return
+ *  - LE_OK if successful.
+ *  - LE_DUPLICATE if a resource by that name exists but with different direction, type or units.
+ *  - LE_NO_MEMORY if the client is not permitted to create that many resources.
+ */
+//--------------------------------------------------------------------------------------------------
+le_result_t admin_CreateOutput
+(
+    const char* path,
+        ///< [IN] Absolute resource tree path.
+    io_DataType_t dataType,
+        ///< [IN] The data type.
+    const char* LE_NONNULL units
+        ///< [IN] e.g., "degC" (see senml); "" = unspecified.
+)
+{
+    LE_DEBUG("'%s' <%s> '%s'.", path, hub_GetDataTypeName(dataType), units);
+
+    resTree_EntryRef_t resRef = resTree_FindEntryAtAbsolutePath(path);
+
+    if (resRef != NULL)
+    {
+        switch (resTree_GetEntryType(resRef))
+        {
+            case ADMIN_ENTRY_TYPE_OUTPUT:
+
+                // Check data type and units to see if they match.
+                if (   (resTree_GetDataType(resRef) != dataType)
+                    || (strcmp(units, resTree_GetUnits(resRef)) != 0))
+                {
+                    return LE_DUPLICATE;
+                }
+
+                // The object already exists.  Nothing more needs to be done.
+                return LE_OK;
+
+            case ADMIN_ENTRY_TYPE_INPUT:
+            case ADMIN_ENTRY_TYPE_OBSERVATION:
+
+                // These conflict.
+                return LE_DUPLICATE;
+
+            case ADMIN_ENTRY_TYPE_NAMESPACE:
+            case ADMIN_ENTRY_TYPE_PLACEHOLDER:
+
+                // These can be upgraded to Output objects by resTree_GetOutput().
+                break;
+
+            case ADMIN_ENTRY_TYPE_NONE:
+
+                LE_FATAL("Unexpected entry type.");
+        }
+    }
+
+    // Get the "/app" namespace first.
+    resTree_EntryRef_t nsRef = resTree_GetEntry(resTree_GetRoot(), "app");
+
+    // Extract the app name from absolute path.
+    char appName[HUB_MAX_ENTRY_NAME_BYTES];
+    if (LE_OK != ExtractAppNameFromAbsolutePath(path, appName, sizeof(appName)))
+    {
+        LE_ERROR("Failed to extract app name from abs path '%s'.", path);
+        return LE_FAULT;
+    }
+
+    LE_DEBUG("App name is '%s'.", appName);
+
+    // Now get the app's namespace under the /app namespace.
+    nsRef = resTree_GetEntry(nsRef, appName);
+
+    // Create the Output resource. Need to convert absolute path to relative one.
+    resRef = resTree_GetOutput(nsRef, path + strlen("/app/") + strlen(appName) + strlen("/"), dataType, units);
+    if (resRef == NULL)
+    {
+        LE_ERROR("Failed to create Output '/app/%s/%s'.", resTree_GetEntryName(nsRef), path);
+        return LE_FAULT;
+    }
+
+    return LE_OK;
+}
+
+//--------------------------------------------------------------------------------------------------
+/**
+ * Delete a resource.
+ *
+ * Does nothing if the resource doesn't exist.
+ */
+//--------------------------------------------------------------------------------------------------
+void admin_DeleteResource
+(
+    const char* path
+        ///< [IN] Absolute resource tree path.
+)
+{
+    LE_DEBUG("'%s'", path);
+
+    // If the resource exists, delete it.
+    resTree_EntryRef_t resRef = resTree_FindEntryAtAbsolutePath(path);
+    if (resRef != NULL)
+    {
+        resTree_DeleteIO(resRef);
+    }
+}
+
+//--------------------------------------------------------------------------------------------------
+/**
+ * Set the example value for a JSON-type Input resource.
+ *
+ * Does nothing if the resource is not found, is not an input, or doesn't have a JSON type.
+ */
+//--------------------------------------------------------------------------------------------------
+void admin_SetJsonExample
+(
+    const char* path,
+        ///< [IN] Absolute resource tree path.
+    const char* example
+        ///< [IN] The example JSON value string.
+)
+{
+    resTree_EntryRef_t resRef = resTree_FindEntryAtAbsolutePath(path);
+    if (resRef == NULL)
+    {
+        LE_ERROR("Resource '%s' does not exist.", path);
+    }
+    else if (resTree_GetEntryType(resRef) != ADMIN_ENTRY_TYPE_INPUT)
+    {
+        LE_ERROR("Resource '%s' is not an input.", path);
+    }
+    else if (resTree_GetDataType(resRef) != IO_DATA_TYPE_JSON)
+    {
+        LE_ERROR("Resource '%s' does not have JSON data type.", path);
+    }
+    else
+    {
+        dataSample_Ref_t sampleRef = dataSample_CreateJson(0, example);
+
+        if (sampleRef != NULL)
+        {
+            resTree_SetJsonExample(resRef, sampleRef);
+        }
+    }
+}
+
+//--------------------------------------------------------------------------------------------------
+/**
+ * Mark an Output resource "optional".  (By default, they are marked "mandatory".)
+ */
+//--------------------------------------------------------------------------------------------------
+void admin_MarkOptional
+(
+    const char* path
+        ///< [IN] Absolute resource tree path.
+)
+{
+    resTree_EntryRef_t resRef = resTree_FindEntryAtAbsolutePath(path);
+    if (resRef == NULL)
+    {
+        LE_KILL_CLIENT("Attempt to mark non-existent resource optional at '%s'.", path);
+    }
+    else if (resTree_GetEntryType(resRef) != ADMIN_ENTRY_TYPE_OUTPUT)
+    {
+        LE_KILL_CLIENT("Attempt to mark non-Output resource optional at '%s'.", path);
+    }
+    else
+    {
+        resTree_MarkOptional(resRef);
+    }
+}

--- a/components/dataHub/dataHub.c
+++ b/components/dataHub/dataHub.c
@@ -39,7 +39,11 @@
  * Component initializer.
  */
 //--------------------------------------------------------------------------------------------------
+#ifndef UNIT_TEST
 COMPONENT_INIT
+#else
+void initDataHub(void)
+#endif
 {
     dataSample_Init();
     handler_Init();

--- a/components/json/json.c
+++ b/components/json/json.c
@@ -511,7 +511,7 @@ static const char* GetMemberName
 {
     size_t i = 0;
 
-    while ((i < buffSize) && 
+    while ((i < buffSize) &&
            (isalnum(*specPtr) || (*specPtr == '_') || (*specPtr == '-')))
     {
         *buffPtr = *specPtr;
@@ -908,8 +908,8 @@ LE_SHARED const char* json_GetDataTypeName
     return "unknown";
 }
 
-
+#ifndef UNIT_TEST
 COMPONENT_INIT
 {
 }
-
+#endif

--- a/components/jsonFormatter/jsonFormatter.c
+++ b/components/jsonFormatter/jsonFormatter.c
@@ -760,8 +760,10 @@ le_result_t GetJsonSnapshotFormatter
     return LE_OK;
 }
 
+#ifndef UNIT_TEST
 /// Component initialisation.
 COMPONENT_INIT
 {
     // Do nothing.
 }
+#endif

--- a/test/admin/Makefile
+++ b/test/admin/Makefile
@@ -1,0 +1,57 @@
+# Makefile for building the unit tests and run them
+# Copyright (C) Sierra Wireless Inc.
+# Requires Legato and cmocka - https://cmocka.org
+
+# Default to wp77xx for backwards compatibility.
+export LEGATO_TARGET ?= wp77xx
+
+TEST_BUILD_DIR = build/test
+
+# Liblegato information for building unit tests ("3rd party" source code)
+LIBLEGATO_INC=-I${LEGATO_ROOT}/framework/include \
+	-I${LEGATO_ROOT}/framework/liblegato/ \
+	-I${LEGATO_ROOT}/framework/daemons/linux/ \
+	-I${LEGATO_ROOT}/build/$(LEGATO_TARGET)/framework/include/ \
+	-I${LEGATO_ROOT}/build/$(LEGATO_TARGET)/3rdParty/inc
+
+TEST_CFLAGS= \
+            -g \
+            -m32 \
+            -Wall \
+            -Werror
+            # -Wextra DataHUb does not compile with -Wextra
+
+# 3rd party compilation options (Legato, libcbor)
+TEST_CFLAGS_3RD_PARTY = -g -m32
+
+TEST_LDFLAGS=-lpthread -ldl -lcmocka -lm
+LIBLEGATO = $(TEST_BUILD_DIR)/liblegato.a
+LIBCBOR = $(TEST_BUILD_DIR)/libcbor.a
+
+LIBLEGATO_SRC=${LEGATO_ROOT}/framework/liblegato/*.c
+LIBLEGATO_LINUX_SRC=${LEGATO_ROOT}/framework/liblegato/linux/*.c
+
+LIBLEGATO_OBJ=$(TEST_BUILD_DIR)/liblegato/*.o $(TEST_BUILD_DIR)/liblegato/linux/*.o
+$(LIBLEGATO): $(LIBLEGATO_SRC) $(LIBLEGATO_LINUX_SRC)
+	mkdir -p $(TEST_BUILD_DIR)/liblegato/
+	mkdir -p $(TEST_BUILD_DIR)/liblegato/linux
+	mkdir -p $(TEST_BUILD_DIR)/cov
+	rm -f $(TEST_BUILD_DIR)/*.o
+	cd $(TEST_BUILD_DIR)/liblegato && cc $(TEST_CFLAGS_3RD_PARTY) -c $(LIBLEGATO_SRC) $(LIBLEGATO_INC)
+	cd $(TEST_BUILD_DIR)/liblegato/linux && cc $(TEST_CFLAGS_3RD_PARTY) -c $(LIBLEGATO_LINUX_SRC) $(LIBLEGATO_INC)
+	ar rcs $(LIBLEGATO) $(LIBLEGATO_OBJ)
+
+DATAHUB_PATH=../../components/dataHub
+DATAHUB_JSON_PATH=../../components/json
+DATAHUB_JSONFORMATTER_PATH=../../components/jsonFormatter
+DATAHUB_SRC=$(wildcard $(DATAHUB_PATH)/*.c) $(wildcard $(DATAHUB_JSON_PATH)/*.c) $(wildcard $(DATAHUB_JSONFORMATTER_PATH)/*.c)
+
+ADMINTEST_SRC=$(wildcard *.c)
+
+.PHONY: tests clean
+tests: $(ADMINTEST_SRC) $(LIBLEGATO)
+	cc $(TEST_CFLAGS) -o $(TEST_BUILD_DIR)/admintest $(ADMINTEST_SRC) $(DATAHUB_SRC) $(LIBLEGATO_OBJ) -I. -I$(DATAHUB_PATH) -I$(DATAHUB_JSON_PATH) -I$(DATAHUB_JSONFORMATTER_PATH) $(LIBLEGATO_INC) -DUNIT_TEST $(TEST_LDFLAGS)
+	build/test/admintest
+
+clean:
+	rm -rf build

--- a/test/admin/admin_common.h
+++ b/test/admin/admin_common.h
@@ -1,0 +1,1347 @@
+
+/*
+ * ====================== WARNING ======================
+ *
+ * THE CONTENTS OF THIS FILE HAVE BEEN AUTO-GENERATED.
+ * DO NOT MODIFY IN ANY WAY.
+ *
+ * ====================== WARNING ======================
+ */
+#ifndef ADMIN_COMMON_H_INCLUDE_GUARD
+#define ADMIN_COMMON_H_INCLUDE_GUARD
+
+
+#include "legato.h"
+
+// Interface specific includes
+#include "io_common.h"
+
+#define IFGEN_ADMIN_PROTOCOL_ID "f6ea69517ad8a32dfeffda9d591390ee"
+#define IFGEN_ADMIN_MSG_SIZE 50103
+
+
+
+//--------------------------------------------------------------------------------------------------
+/**
+ * Maximum number of characters in a JSON extraction specifier string (excluding null terminator).
+ */
+//--------------------------------------------------------------------------------------------------
+#define ADMIN_MAX_JSON_EXTRACTOR_LEN 63
+
+//--------------------------------------------------------------------------------------------------
+/**
+ * Maximum number of optional transform parameters for an observation buffer.
+ */
+//--------------------------------------------------------------------------------------------------
+#define ADMIN_MAX_TRANSFORM_PARAMETERS 8
+
+//--------------------------------------------------------------------------------------------------
+/**
+ * Enumerates the different types of entries that can exist in the resource tree.
+ */
+//--------------------------------------------------------------------------------------------------
+typedef enum
+{
+    ADMIN_ENTRY_TYPE_NONE = 0,
+        ///< Not an entry
+    ADMIN_ENTRY_TYPE_NAMESPACE = 1,
+        ///< Namespace
+    ADMIN_ENTRY_TYPE_INPUT = 2,
+        ///< Input
+    ADMIN_ENTRY_TYPE_OUTPUT = 3,
+        ///< Output
+    ADMIN_ENTRY_TYPE_OBSERVATION = 4,
+        ///< Observation
+    ADMIN_ENTRY_TYPE_PLACEHOLDER = 5
+        ///< Placeholder
+}
+admin_EntryType_t;
+
+
+//--------------------------------------------------------------------------------------------------
+/**
+ * Enumerates the different operations on a Resource - add and remove.
+ */
+//--------------------------------------------------------------------------------------------------
+typedef enum
+{
+    ADMIN_RESOURCE_ADDED = 0,
+        ///<
+    ADMIN_RESOURCE_REMOVED = 1
+        ///<
+}
+admin_ResourceOperationType_t;
+
+
+//--------------------------------------------------------------------------------------------------
+/**
+ * Enumerates the different types of transforms which can be applied to an observation buffer
+ */
+//--------------------------------------------------------------------------------------------------
+typedef enum
+{
+    ADMIN_OBS_TRANSFORM_TYPE_NONE = 0,
+        ///< No transformation
+    ADMIN_OBS_TRANSFORM_TYPE_MEAN = 1,
+        ///< Mean
+    ADMIN_OBS_TRANSFORM_TYPE_STDDEV = 2,
+        ///< Standard Deviation
+    ADMIN_OBS_TRANSFORM_TYPE_MAX = 3,
+        ///< Maximum value in buffer
+    ADMIN_OBS_TRANSFORM_TYPE_MIN = 4
+        ///< Minimum value in buffer
+}
+admin_TransformType_t;
+
+
+//--------------------------------------------------------------------------------------------------
+/**
+ * Reference type used by Add/Remove functions for EVENT 'admin_TriggerPush'
+ */
+//--------------------------------------------------------------------------------------------------
+typedef struct admin_TriggerPushHandler* admin_TriggerPushHandlerRef_t;
+
+
+//--------------------------------------------------------------------------------------------------
+/**
+ * Reference type used by Add/Remove functions for EVENT 'admin_BooleanPush'
+ */
+//--------------------------------------------------------------------------------------------------
+typedef struct admin_BooleanPushHandler* admin_BooleanPushHandlerRef_t;
+
+
+//--------------------------------------------------------------------------------------------------
+/**
+ * Reference type used by Add/Remove functions for EVENT 'admin_NumericPush'
+ */
+//--------------------------------------------------------------------------------------------------
+typedef struct admin_NumericPushHandler* admin_NumericPushHandlerRef_t;
+
+
+//--------------------------------------------------------------------------------------------------
+/**
+ * Reference type used by Add/Remove functions for EVENT 'admin_StringPush'
+ */
+//--------------------------------------------------------------------------------------------------
+typedef struct admin_StringPushHandler* admin_StringPushHandlerRef_t;
+
+
+//--------------------------------------------------------------------------------------------------
+/**
+ * Reference type used by Add/Remove functions for EVENT 'admin_JsonPush'
+ */
+//--------------------------------------------------------------------------------------------------
+typedef struct admin_JsonPushHandler* admin_JsonPushHandlerRef_t;
+
+
+//--------------------------------------------------------------------------------------------------
+/**
+ * Reference type used by Add/Remove functions for EVENT 'admin_ResourceTreeChange'
+ */
+//--------------------------------------------------------------------------------------------------
+typedef struct admin_ResourceTreeChangeHandler* admin_ResourceTreeChangeHandlerRef_t;
+
+
+//--------------------------------------------------------------------------------------------------
+/**
+ * Callback function for pushing triggers to an output
+ */
+//--------------------------------------------------------------------------------------------------
+typedef void (*admin_TriggerPushHandlerFunc_t)
+(
+        double timestamp,
+        ///< Timestamp in seconds since the Epoch 1970-01-01 00:00:00 +0000 (UTC).
+        void* contextPtr
+        ///<
+);
+
+//--------------------------------------------------------------------------------------------------
+/**
+ * Callback function for pushing Boolean values to an output
+ */
+//--------------------------------------------------------------------------------------------------
+typedef void (*admin_BooleanPushHandlerFunc_t)
+(
+        double timestamp,
+        ///< Timestamp in seconds since the Epoch 1970-01-01 00:00:00 +0000 (UTC).
+        bool value,
+        ///<
+        void* contextPtr
+        ///<
+);
+
+//--------------------------------------------------------------------------------------------------
+/**
+ * Callback function for pushing numeric values to an output
+ */
+//--------------------------------------------------------------------------------------------------
+typedef void (*admin_NumericPushHandlerFunc_t)
+(
+        double timestamp,
+        ///< Timestamp in seconds since the Epoch 1970-01-01 00:00:00 +0000 (UTC).
+        double value,
+        ///<
+        void* contextPtr
+        ///<
+);
+
+//--------------------------------------------------------------------------------------------------
+/**
+ * Callback function for pushing string values to an output
+ */
+//--------------------------------------------------------------------------------------------------
+typedef void (*admin_StringPushHandlerFunc_t)
+(
+        double timestamp,
+        ///< Timestamp in seconds since the Epoch 1970-01-01 00:00:00 +0000 (UTC).
+        const char* LE_NONNULL value,
+        ///<
+        void* contextPtr
+        ///<
+);
+
+//--------------------------------------------------------------------------------------------------
+/**
+ * Callback function for pushing JSON values to an output
+ */
+//--------------------------------------------------------------------------------------------------
+typedef void (*admin_JsonPushHandlerFunc_t)
+(
+        double timestamp,
+        ///< Timestamp in seconds since the Epoch 1970-01-01 00:00:00 +0000 (UTC).
+        const char* LE_NONNULL value,
+        ///<
+        void* contextPtr
+        ///<
+);
+
+//--------------------------------------------------------------------------------------------------
+/**
+ * Register a handler, to be called back whenever a Resource is added or removed
+ */
+//--------------------------------------------------------------------------------------------------
+typedef void (*admin_ResourceTreeChangeHandlerFunc_t)
+(
+        const char* LE_NONNULL path,
+        ///< Absolute path of the resource.
+        admin_EntryType_t entryType,
+        ///< The type of the Resource (Input / Output / ...)
+        admin_ResourceOperationType_t operation,
+        ///< Whether the Resource was added or Removed
+        void* contextPtr
+        ///<
+);
+
+
+//--------------------------------------------------------------------------------------------------
+/**
+ * Get if this client bound locally.
+ */
+//--------------------------------------------------------------------------------------------------
+LE_SHARED bool ifgen_admin_HasLocalBinding
+(
+    void
+);
+
+
+//--------------------------------------------------------------------------------------------------
+/**
+ * Init data that is common across all threads
+ */
+//--------------------------------------------------------------------------------------------------
+LE_SHARED void ifgen_admin_InitCommonData
+(
+    void
+);
+
+
+//--------------------------------------------------------------------------------------------------
+/**
+ * Perform common initialization and open a session
+ */
+//--------------------------------------------------------------------------------------------------
+LE_SHARED le_result_t ifgen_admin_OpenSession
+(
+    le_msg_SessionRef_t _ifgen_sessionRef,
+    bool isBlocking
+);
+
+//--------------------------------------------------------------------------------------------------
+/**
+ * Push a trigger type data sample to a resource.
+ *
+ * @note If the resource doesn't exist, the push will be ignored.  This will not cause a
+ *       Placeholder resource to be created.
+ */
+//--------------------------------------------------------------------------------------------------
+LE_SHARED void ifgen_admin_PushTrigger
+(
+    le_msg_SessionRef_t _ifgen_sessionRef,
+        const char* LE_NONNULL path,
+        ///< [IN] Absolute resource tree path.
+        double timestamp
+        ///< [IN] Timestamp in seconds since the Epoch 1970-01-01 00:00:00 +0000 (UTC).
+        ///< Zero = now (i.e., generate a timestamp for me).
+);
+
+//--------------------------------------------------------------------------------------------------
+/**
+ * Push a Boolean type data sample to a resource.
+ *
+ * @note If the resource doesn't exist, the push will be ignored.  This will not cause a
+ *       Placeholder resource to be created.
+ */
+//--------------------------------------------------------------------------------------------------
+LE_SHARED void ifgen_admin_PushBoolean
+(
+    le_msg_SessionRef_t _ifgen_sessionRef,
+        const char* LE_NONNULL path,
+        ///< [IN] Absolute resource tree path.
+        double timestamp,
+        ///< [IN] Timestamp in seconds since the Epoch 1970-01-01 00:00:00 +0000 (UTC).
+        ///< Zero = now (i.e., generate a timestamp for me).
+        bool value
+        ///< [IN]
+);
+
+//--------------------------------------------------------------------------------------------------
+/**
+ * Push a numeric type data sample to a resource.
+ *
+ * @note If the resource doesn't exist, the push will be ignored.  This will not cause a
+ *       Placeholder resource to be created.
+ */
+//--------------------------------------------------------------------------------------------------
+LE_SHARED void ifgen_admin_PushNumeric
+(
+    le_msg_SessionRef_t _ifgen_sessionRef,
+        const char* LE_NONNULL path,
+        ///< [IN] Absolute resource tree path.
+        double timestamp,
+        ///< [IN] Timestamp in seconds since the Epoch 1970-01-01 00:00:00 +0000 (UTC).
+        ///< Zero = now (i.e., generate a timestamp for me).
+        double value
+        ///< [IN]
+);
+
+//--------------------------------------------------------------------------------------------------
+/**
+ * Push a string type data sample to a resource.
+ *
+ * @note If the resource doesn't exist, the push will be ignored.  This will not cause a
+ *       Placeholder resource to be created.
+ */
+//--------------------------------------------------------------------------------------------------
+LE_SHARED void ifgen_admin_PushString
+(
+    le_msg_SessionRef_t _ifgen_sessionRef,
+        const char* LE_NONNULL path,
+        ///< [IN] Absolute resource tree path.
+        double timestamp,
+        ///< [IN] Timestamp in seconds since the Epoch 1970-01-01 00:00:00 +0000 (UTC).
+        ///< Zero = now (i.e., generate a timestamp for me).
+        const char* LE_NONNULL value
+        ///< [IN]
+);
+
+//--------------------------------------------------------------------------------------------------
+/**
+ * Push a JSON data sample to a resource.
+ *
+ * @note If the resource doesn't exist, the push will be ignored.  This will not cause a
+ *       Placeholder resource to be created.
+ */
+//--------------------------------------------------------------------------------------------------
+LE_SHARED void ifgen_admin_PushJson
+(
+    le_msg_SessionRef_t _ifgen_sessionRef,
+        const char* LE_NONNULL path,
+        ///< [IN] Absolute resource tree path.
+        double timestamp,
+        ///< [IN] Timestamp in seconds since the Epoch 1970-01-01 00:00:00 +0000 (UTC).
+        ///< Zero = now (i.e., generate a timestamp for me).
+        const char* LE_NONNULL value
+        ///< [IN]
+);
+
+//--------------------------------------------------------------------------------------------------
+/**
+ * Add handler function for EVENT 'admin_TriggerPush'
+ */
+//--------------------------------------------------------------------------------------------------
+LE_SHARED admin_TriggerPushHandlerRef_t ifgen_admin_AddTriggerPushHandler
+(
+    le_msg_SessionRef_t _ifgen_sessionRef,
+        const char* LE_NONNULL path,
+        ///< [IN] Absolute path of resource.
+        admin_TriggerPushHandlerFunc_t callbackPtr,
+        ///< [IN]
+        void* contextPtr
+        ///< [IN]
+);
+
+//--------------------------------------------------------------------------------------------------
+/**
+ * Remove handler function for EVENT 'admin_TriggerPush'
+ */
+//--------------------------------------------------------------------------------------------------
+LE_SHARED void ifgen_admin_RemoveTriggerPushHandler
+(
+    le_msg_SessionRef_t _ifgen_sessionRef,
+        admin_TriggerPushHandlerRef_t handlerRef
+        ///< [IN]
+);
+
+//--------------------------------------------------------------------------------------------------
+/**
+ * Add handler function for EVENT 'admin_BooleanPush'
+ */
+//--------------------------------------------------------------------------------------------------
+LE_SHARED admin_BooleanPushHandlerRef_t ifgen_admin_AddBooleanPushHandler
+(
+    le_msg_SessionRef_t _ifgen_sessionRef,
+        const char* LE_NONNULL path,
+        ///< [IN] Absolute path of resource.
+        admin_BooleanPushHandlerFunc_t callbackPtr,
+        ///< [IN]
+        void* contextPtr
+        ///< [IN]
+);
+
+//--------------------------------------------------------------------------------------------------
+/**
+ * Remove handler function for EVENT 'admin_BooleanPush'
+ */
+//--------------------------------------------------------------------------------------------------
+LE_SHARED void ifgen_admin_RemoveBooleanPushHandler
+(
+    le_msg_SessionRef_t _ifgen_sessionRef,
+        admin_BooleanPushHandlerRef_t handlerRef
+        ///< [IN]
+);
+
+//--------------------------------------------------------------------------------------------------
+/**
+ * Add handler function for EVENT 'admin_NumericPush'
+ */
+//--------------------------------------------------------------------------------------------------
+LE_SHARED admin_NumericPushHandlerRef_t ifgen_admin_AddNumericPushHandler
+(
+    le_msg_SessionRef_t _ifgen_sessionRef,
+        const char* LE_NONNULL path,
+        ///< [IN] Absolute path of resource.
+        admin_NumericPushHandlerFunc_t callbackPtr,
+        ///< [IN]
+        void* contextPtr
+        ///< [IN]
+);
+
+//--------------------------------------------------------------------------------------------------
+/**
+ * Remove handler function for EVENT 'admin_NumericPush'
+ */
+//--------------------------------------------------------------------------------------------------
+LE_SHARED void ifgen_admin_RemoveNumericPushHandler
+(
+    le_msg_SessionRef_t _ifgen_sessionRef,
+        admin_NumericPushHandlerRef_t handlerRef
+        ///< [IN]
+);
+
+//--------------------------------------------------------------------------------------------------
+/**
+ * Add handler function for EVENT 'admin_StringPush'
+ */
+//--------------------------------------------------------------------------------------------------
+LE_SHARED admin_StringPushHandlerRef_t ifgen_admin_AddStringPushHandler
+(
+    le_msg_SessionRef_t _ifgen_sessionRef,
+        const char* LE_NONNULL path,
+        ///< [IN] Absolute path of resource.
+        admin_StringPushHandlerFunc_t callbackPtr,
+        ///< [IN]
+        void* contextPtr
+        ///< [IN]
+);
+
+//--------------------------------------------------------------------------------------------------
+/**
+ * Remove handler function for EVENT 'admin_StringPush'
+ */
+//--------------------------------------------------------------------------------------------------
+LE_SHARED void ifgen_admin_RemoveStringPushHandler
+(
+    le_msg_SessionRef_t _ifgen_sessionRef,
+        admin_StringPushHandlerRef_t handlerRef
+        ///< [IN]
+);
+
+//--------------------------------------------------------------------------------------------------
+/**
+ * Add handler function for EVENT 'admin_JsonPush'
+ */
+//--------------------------------------------------------------------------------------------------
+LE_SHARED admin_JsonPushHandlerRef_t ifgen_admin_AddJsonPushHandler
+(
+    le_msg_SessionRef_t _ifgen_sessionRef,
+        const char* LE_NONNULL path,
+        ///< [IN] Absolute path of resource.
+        admin_JsonPushHandlerFunc_t callbackPtr,
+        ///< [IN]
+        void* contextPtr
+        ///< [IN]
+);
+
+//--------------------------------------------------------------------------------------------------
+/**
+ * Remove handler function for EVENT 'admin_JsonPush'
+ */
+//--------------------------------------------------------------------------------------------------
+LE_SHARED void ifgen_admin_RemoveJsonPushHandler
+(
+    le_msg_SessionRef_t _ifgen_sessionRef,
+        admin_JsonPushHandlerRef_t handlerRef
+        ///< [IN]
+);
+
+//--------------------------------------------------------------------------------------------------
+/**
+ * Creates a data flow route from one resource to another by setting the data source for the
+ * destination resource.  If the destination resource already has a source resource, it will be
+ * replaced. Does nothing if the route already exists.
+ *
+ * Creates Placeholders for any source or destination resource that doesn't yet exist in the
+ * resource tree.
+ *
+ * @note While an Input can have a source configured, it will ignore anything pushed to it
+ *       from other resources via that route. Inputs only accept values pushed by the app that
+ *       created them or from the administrator pushed directly to them via one of the
+ *       @ref c_dataHubAdmin_Pushing "Push functions".
+ *
+ * @return
+ *  - LE_OK if route already existed or new route was successfully created.
+ *  - LE_BAD_PARAMETER if one of the paths is invalid.
+ *  - LE_DUPLICATE if the addition of this route would result in a loop.
+ */
+//--------------------------------------------------------------------------------------------------
+LE_SHARED le_result_t ifgen_admin_SetSource
+(
+    le_msg_SessionRef_t _ifgen_sessionRef,
+        const char* LE_NONNULL destPath,
+        ///< [IN] Absolute path of destination resource.
+        const char* LE_NONNULL srcPath
+        ///< [IN] Absolute path of source resource.
+);
+
+//--------------------------------------------------------------------------------------------------
+/**
+ * Fetches the data flow source resource from which a given resource expects to receive data
+ * samples.
+ *
+ * @note While an Input can have a source configured, it will ignore anything pushed to it
+ *       from other resources via that route. Inputs only accept values pushed by the app that
+ *       created them or from the administrator pushed directly to them via one of the
+ *       @ref c_dataHubAdmin_Pushing "Push functions".
+ *
+ * @return
+ *  - LE_OK if successful.
+ *  - LE_BAD_PARAMETER if the path is invalid.
+ *  - LE_NOT_FOUND if the resource doesn't exist or doesn't have a source.
+ *  - LE_OVERFLOW if the path of the source resource won't fit in the string buffer provided.
+ */
+//--------------------------------------------------------------------------------------------------
+LE_SHARED le_result_t ifgen_admin_GetSource
+(
+    le_msg_SessionRef_t _ifgen_sessionRef,
+        const char* LE_NONNULL destPath,
+        ///< [IN] Absolute path of destination resource.
+        char* srcPath,
+        ///< [OUT] Absolute path of source resource.
+        size_t srcPathSize
+        ///< [IN]
+);
+
+//--------------------------------------------------------------------------------------------------
+/**
+ * Remove the data flow route into a resource.
+ */
+//--------------------------------------------------------------------------------------------------
+LE_SHARED void ifgen_admin_RemoveSource
+(
+    le_msg_SessionRef_t _ifgen_sessionRef,
+        const char* LE_NONNULL destPath
+        ///< [IN] Absolute path of destination resource.
+);
+
+//--------------------------------------------------------------------------------------------------
+/**
+ * Create an Observation in the /obs/ namespace.
+ *
+ *  @return
+ *  - LE_OK if the observation was created or it already existed.
+ *  - LE_BAD_PARAMETER if the path is invalid.
+ */
+//--------------------------------------------------------------------------------------------------
+LE_SHARED le_result_t ifgen_admin_CreateObs
+(
+    le_msg_SessionRef_t _ifgen_sessionRef,
+        const char* LE_NONNULL path
+        ///< [IN] Path within the /obs/ namespace.
+);
+
+//--------------------------------------------------------------------------------------------------
+/**
+ * Delete an Observation in the /obs/ namespace.
+ */
+//--------------------------------------------------------------------------------------------------
+LE_SHARED void ifgen_admin_DeleteObs
+(
+    le_msg_SessionRef_t _ifgen_sessionRef,
+        const char* LE_NONNULL path
+        ///< [IN] Path within the /obs/ namespace.
+);
+
+//--------------------------------------------------------------------------------------------------
+/**
+ * Set the minimum period between data samples accepted by a given Observation.
+ *
+ * This is used to throttle the rate of data passing into and through an Observation.
+ */
+//--------------------------------------------------------------------------------------------------
+LE_SHARED void ifgen_admin_SetMinPeriod
+(
+    le_msg_SessionRef_t _ifgen_sessionRef,
+        const char* LE_NONNULL path,
+        ///< [IN] Path within the /obs/ namespace.
+        double minPeriod
+        ///< [IN] The minimum period, in seconds.
+);
+
+//--------------------------------------------------------------------------------------------------
+/**
+ * Get the minimum period between data samples accepted by a given Observation.
+ *
+ * @return The value, or NAN (not a number) if not set.
+ */
+//--------------------------------------------------------------------------------------------------
+LE_SHARED double ifgen_admin_GetMinPeriod
+(
+    le_msg_SessionRef_t _ifgen_sessionRef,
+        const char* LE_NONNULL path
+        ///< [IN] Path within the /obs/ namespace.
+);
+
+//--------------------------------------------------------------------------------------------------
+/**
+ * Set the highest value in a range that will be accepted by a given Observation.
+ *
+ * Ignored for all non-numeric types except Boolean for which non-zero = true and zero = false.
+ */
+//--------------------------------------------------------------------------------------------------
+LE_SHARED void ifgen_admin_SetHighLimit
+(
+    le_msg_SessionRef_t _ifgen_sessionRef,
+        const char* LE_NONNULL path,
+        ///< [IN] Path within the /obs/ namespace.
+        double highLimit
+        ///< [IN] The highest value in the range, or NAN (not a number) to remove limit.
+);
+
+//--------------------------------------------------------------------------------------------------
+/**
+ * Get the highest value in a range that will be accepted by a given Observation.
+ *
+ * @return The value, or NAN (not a number) if not set.
+ */
+//--------------------------------------------------------------------------------------------------
+LE_SHARED double ifgen_admin_GetHighLimit
+(
+    le_msg_SessionRef_t _ifgen_sessionRef,
+        const char* LE_NONNULL path
+        ///< [IN] Path within the /obs/ namespace.
+);
+
+//--------------------------------------------------------------------------------------------------
+/**
+ * Set the lowest value in a range that will be accepted by a given Observation.
+ *
+ * Ignored for all non-numeric types except Boolean for which non-zero = true and zero = false.
+ */
+//--------------------------------------------------------------------------------------------------
+LE_SHARED void ifgen_admin_SetLowLimit
+(
+    le_msg_SessionRef_t _ifgen_sessionRef,
+        const char* LE_NONNULL path,
+        ///< [IN] Path within the /obs/ namespace.
+        double lowLimit
+        ///< [IN] The lowest value in the range, or NAN (not a number) to remove limit.
+);
+
+//--------------------------------------------------------------------------------------------------
+/**
+ * Get the lowest value in a range that will be accepted by a given Observation.
+ *
+ * @return The value, or NAN (not a number) if not set.
+ */
+//--------------------------------------------------------------------------------------------------
+LE_SHARED double ifgen_admin_GetLowLimit
+(
+    le_msg_SessionRef_t _ifgen_sessionRef,
+        const char* LE_NONNULL path
+        ///< [IN] Path within the /obs/ namespace.
+);
+
+//--------------------------------------------------------------------------------------------------
+/**
+ * Set the magnitude that a new value must vary from the current value to be accepted by
+ * a given Observation.
+ *
+ * Ignored for trigger types.
+ *
+ * For all other types, any non-zero value means accept any change, but drop if the same as current.
+ */
+//--------------------------------------------------------------------------------------------------
+LE_SHARED void ifgen_admin_SetChangeBy
+(
+    le_msg_SessionRef_t _ifgen_sessionRef,
+        const char* LE_NONNULL path,
+        ///< [IN] Path within the /obs/ namespace.
+        double change
+        ///< [IN] The magnitude, or either zero or NAN (not a number) to remove limit.
+);
+
+//--------------------------------------------------------------------------------------------------
+/**
+ * Get the magnitude that a new value must vary from the current value to be accepted by
+ * a given Observation.
+ *
+ * @return The value, or NAN (not a number) if not set.
+ */
+//--------------------------------------------------------------------------------------------------
+LE_SHARED double ifgen_admin_GetChangeBy
+(
+    le_msg_SessionRef_t _ifgen_sessionRef,
+        const char* LE_NONNULL path
+        ///< [IN] Path within the /obs/ namespace.
+);
+
+//--------------------------------------------------------------------------------------------------
+/**
+ * Perform a transform on an observation's buffered data. Value of the observation will be
+ * the output of the transform
+ *
+ * Ignored for all non-numeric types except Boolean for which non-zero = true and zero = false.
+ */
+//--------------------------------------------------------------------------------------------------
+LE_SHARED void ifgen_admin_SetTransform
+(
+    le_msg_SessionRef_t _ifgen_sessionRef,
+        const char* LE_NONNULL path,
+        ///< [IN] Path within the /obs/ namespace.
+        admin_TransformType_t transformType,
+        ///< [IN] Type of transform to apply
+        const double* paramsPtr,
+        ///< [IN] Optional parameter list
+        size_t paramsSize
+        ///< [IN]
+);
+
+//--------------------------------------------------------------------------------------------------
+/**
+ * Get the type of transform currently applied to an Observation.
+ *
+ * @return The TransformType
+ */
+//--------------------------------------------------------------------------------------------------
+LE_SHARED admin_TransformType_t ifgen_admin_GetTransform
+(
+    le_msg_SessionRef_t _ifgen_sessionRef,
+        const char* LE_NONNULL path
+        ///< [IN] Path within the /obs/ namespace.
+);
+
+//--------------------------------------------------------------------------------------------------
+/**
+ * Set the JSON member/element specifier for extraction of data from within a structured JSON
+ * value received by a given Observation.
+ *
+ * If this is set, all non-JSON data will be ignored, and all JSON data that does not contain the
+ * the specified object member or array element will also be ignored.
+ *
+ * To clear, set to an empty string.
+ */
+//--------------------------------------------------------------------------------------------------
+LE_SHARED void ifgen_admin_SetJsonExtraction
+(
+    le_msg_SessionRef_t _ifgen_sessionRef,
+        const char* LE_NONNULL path,
+        ///< [IN] Path within the /obs/ namespace.
+        const char* LE_NONNULL extractionSpec
+        ///< [IN] str specifying member/element to extract.
+);
+
+//--------------------------------------------------------------------------------------------------
+/**
+ * Get the JSON member/element specifier for extraction of data from within a structured JSON
+ * value received by a given Observation.
+ *
+ * @return
+ *  - LE_OK if successful
+ *  - LE_NOT_FOUND if the resource doesn't exist or doesn't have a JSON extraction specifier set.
+ *  - LE_OVERFLOW if the JSON extraction specifier won't fit in the string buffer provided.
+ */
+//--------------------------------------------------------------------------------------------------
+LE_SHARED le_result_t ifgen_admin_GetJsonExtraction
+(
+    le_msg_SessionRef_t _ifgen_sessionRef,
+        const char* LE_NONNULL path,
+        ///< [IN] Path within the /obs/ namespace.
+        char* result,
+        ///< [OUT] Buffer where result goes if LE_OK returned.
+        size_t resultSize
+        ///< [IN]
+);
+
+//--------------------------------------------------------------------------------------------------
+/**
+ * Set the maximum number of data samples to buffer in a given Observation.  Buffers are FIFO
+ * circular buffers. When full, the buffer drops the oldest value to make room for a new addition.
+ */
+//--------------------------------------------------------------------------------------------------
+LE_SHARED void ifgen_admin_SetBufferMaxCount
+(
+    le_msg_SessionRef_t _ifgen_sessionRef,
+        const char* LE_NONNULL path,
+        ///< [IN] Path within the /obs/ namespace.
+        uint32_t count
+        ///< [IN] The number of samples to buffer (0 = remove setting).
+);
+
+//--------------------------------------------------------------------------------------------------
+/**
+ * Get the buffer size setting for a given Observation.
+ *
+ * @return The buffer size (in number of samples) or 0 if not set or the Observation does not exist.
+ */
+//--------------------------------------------------------------------------------------------------
+LE_SHARED uint32_t ifgen_admin_GetBufferMaxCount
+(
+    le_msg_SessionRef_t _ifgen_sessionRef,
+        const char* LE_NONNULL path
+        ///< [IN] Path within the /obs/ namespace.
+);
+
+//--------------------------------------------------------------------------------------------------
+/**
+ * Set the minimum time between backups of an Observation's buffer to non-volatile storage.
+ * If the buffer's size is non-zero and the backup period is non-zero, then the buffer will be
+ * backed-up to non-volatile storage when it changes, but never more often than this period setting
+ * specifies.
+ */
+//--------------------------------------------------------------------------------------------------
+LE_SHARED void ifgen_admin_SetBufferBackupPeriod
+(
+    le_msg_SessionRef_t _ifgen_sessionRef,
+        const char* LE_NONNULL path,
+        ///< [IN] Path within the /obs/ namespace.
+        uint32_t seconds
+        ///< [IN] The minimum number of seconds between backups (0 = disable backups)
+);
+
+//--------------------------------------------------------------------------------------------------
+/**
+ * Get the minimum time between backups of an Observation's buffer to non-volatile storage.
+ * See admin_SetBufferBackupPeriod() for more information.
+ *
+ * @return The buffer backup period (in seconds) or 0 if backups are disabled or the Observation
+ *         does not exist.
+ */
+//--------------------------------------------------------------------------------------------------
+LE_SHARED uint32_t ifgen_admin_GetBufferBackupPeriod
+(
+    le_msg_SessionRef_t _ifgen_sessionRef,
+        const char* LE_NONNULL path
+        ///< [IN] Path within the /obs/ namespace.
+);
+
+//--------------------------------------------------------------------------------------------------
+/**
+ * Set the default value of a resource to a Boolean value.
+ */
+//--------------------------------------------------------------------------------------------------
+LE_SHARED void ifgen_admin_SetBooleanDefault
+(
+    le_msg_SessionRef_t _ifgen_sessionRef,
+        const char* LE_NONNULL path,
+        ///< [IN] Absolute path of the resource.
+        bool value
+        ///< [IN]
+);
+
+//--------------------------------------------------------------------------------------------------
+/**
+ * Set the default value of a resource to a numeric value.
+ */
+//--------------------------------------------------------------------------------------------------
+LE_SHARED void ifgen_admin_SetNumericDefault
+(
+    le_msg_SessionRef_t _ifgen_sessionRef,
+        const char* LE_NONNULL path,
+        ///< [IN] Absolute path of the resource.
+        double value
+        ///< [IN]
+);
+
+//--------------------------------------------------------------------------------------------------
+/**
+ * Set the default value of a resource to a string value.
+ */
+//--------------------------------------------------------------------------------------------------
+LE_SHARED void ifgen_admin_SetStringDefault
+(
+    le_msg_SessionRef_t _ifgen_sessionRef,
+        const char* LE_NONNULL path,
+        ///< [IN] Absolute path of the resource.
+        const char* LE_NONNULL value
+        ///< [IN]
+);
+
+//--------------------------------------------------------------------------------------------------
+/**
+ * Set the default value of a resource to a JSON value.
+ */
+//--------------------------------------------------------------------------------------------------
+LE_SHARED void ifgen_admin_SetJsonDefault
+(
+    le_msg_SessionRef_t _ifgen_sessionRef,
+        const char* LE_NONNULL path,
+        ///< [IN] Absolute path of the resource.
+        const char* LE_NONNULL value
+        ///< [IN]
+);
+
+//--------------------------------------------------------------------------------------------------
+/**
+ * Discover whether a given resource has a default value.
+ *
+ * @return true if there is a default value set, false if not.
+ */
+//--------------------------------------------------------------------------------------------------
+LE_SHARED bool ifgen_admin_HasDefault
+(
+    le_msg_SessionRef_t _ifgen_sessionRef,
+        const char* LE_NONNULL path
+        ///< [IN] Absolute path of the resource.
+);
+
+//--------------------------------------------------------------------------------------------------
+/**
+ * Get the data type of the default value that is currently set on a given resource.
+ *
+ * @return The data type, or IO_DATA_TYPE_TRIGGER if not set.
+ */
+//--------------------------------------------------------------------------------------------------
+LE_SHARED io_DataType_t ifgen_admin_GetDefaultDataType
+(
+    le_msg_SessionRef_t _ifgen_sessionRef,
+        const char* LE_NONNULL path
+        ///< [IN] Absolute path of the resource.
+);
+
+//--------------------------------------------------------------------------------------------------
+/**
+ * Get the default value of a resource, if it is Boolean.
+ *
+ * @return the default value, or false if not set or set to another data type.
+ */
+//--------------------------------------------------------------------------------------------------
+LE_SHARED bool ifgen_admin_GetBooleanDefault
+(
+    le_msg_SessionRef_t _ifgen_sessionRef,
+        const char* LE_NONNULL path
+        ///< [IN] Absolute path of the resource.
+);
+
+//--------------------------------------------------------------------------------------------------
+/**
+ * Get the default value, if it is numeric.
+ *
+ * @return the default value, or NAN (not a number) if not set or set to another data type.
+ */
+//--------------------------------------------------------------------------------------------------
+LE_SHARED double ifgen_admin_GetNumericDefault
+(
+    le_msg_SessionRef_t _ifgen_sessionRef,
+        const char* LE_NONNULL path
+        ///< [IN] Absolute path of the resource.
+);
+
+//--------------------------------------------------------------------------------------------------
+/**
+ * Get the default value, if it is a string.
+ *
+ * @return
+ *  - LE_OK if successful,
+ *  - LE_OVERFLOW if the buffer provided is too small to hold the value.
+ *  - LE_NOT_FOUND if the resource doesn't have a string default value set.
+ */
+//--------------------------------------------------------------------------------------------------
+LE_SHARED le_result_t ifgen_admin_GetStringDefault
+(
+    le_msg_SessionRef_t _ifgen_sessionRef,
+        const char* LE_NONNULL path,
+        ///< [IN] Absolute path of the resource.
+        char* value,
+        ///< [OUT]
+        size_t valueSize
+        ///< [IN]
+);
+
+//--------------------------------------------------------------------------------------------------
+/**
+ * Get the default value, in JSON format.
+ *
+ * @note This works for any type of default value.
+ *
+ * @return
+ *  - LE_OK if successful,
+ *  - LE_OVERFLOW if the buffer provided is too small to hold the value.
+ *  - LE_NOT_FOUND if the resource doesn't have a default value set.
+ */
+//--------------------------------------------------------------------------------------------------
+LE_SHARED le_result_t ifgen_admin_GetJsonDefault
+(
+    le_msg_SessionRef_t _ifgen_sessionRef,
+        const char* LE_NONNULL path,
+        ///< [IN] Absolute path of the resource.
+        char* value,
+        ///< [OUT]
+        size_t valueSize
+        ///< [IN]
+);
+
+//--------------------------------------------------------------------------------------------------
+/**
+ * Remove any default value on a given resource.
+ */
+//--------------------------------------------------------------------------------------------------
+LE_SHARED void ifgen_admin_RemoveDefault
+(
+    le_msg_SessionRef_t _ifgen_sessionRef,
+        const char* LE_NONNULL path
+        ///< [IN] Absolute path of the resource.
+);
+
+//--------------------------------------------------------------------------------------------------
+/**
+ * Set an override of Boolean type on a given resource.
+ *
+ * @note Override will be ignored by an Input or Output resource if the override's data type
+ *       does not match the data type of the Input or Output.
+ */
+//--------------------------------------------------------------------------------------------------
+LE_SHARED void ifgen_admin_SetBooleanOverride
+(
+    le_msg_SessionRef_t _ifgen_sessionRef,
+        const char* LE_NONNULL path,
+        ///< [IN] Absolute path of the resource.
+        bool value
+        ///< [IN]
+);
+
+//--------------------------------------------------------------------------------------------------
+/**
+ * Set an override of numeric type on a given resource.
+ *
+ * @note Override will be ignored by an Input or Output resource if the override's data type
+ *       does not match the data type of the Input or Output.
+ */
+//--------------------------------------------------------------------------------------------------
+LE_SHARED void ifgen_admin_SetNumericOverride
+(
+    le_msg_SessionRef_t _ifgen_sessionRef,
+        const char* LE_NONNULL path,
+        ///< [IN] Absolute path of the resource.
+        double value
+        ///< [IN]
+);
+
+//--------------------------------------------------------------------------------------------------
+/**
+ * Set an override of string type on a given resource.
+ *
+ * @note Override will be ignored by an Input or Output resource if the override's data type
+ *       does not match the data type of the Input or Output.
+ */
+//--------------------------------------------------------------------------------------------------
+LE_SHARED void ifgen_admin_SetStringOverride
+(
+    le_msg_SessionRef_t _ifgen_sessionRef,
+        const char* LE_NONNULL path,
+        ///< [IN] Absolute path of the resource.
+        const char* LE_NONNULL value
+        ///< [IN]
+);
+
+//--------------------------------------------------------------------------------------------------
+/**
+ * Set an override of JSON type on a given resource.
+ *
+ * @note Override will be ignored by an Input or Output resource if the override's data type
+ *       does not match the data type of the Input or Output.
+ */
+//--------------------------------------------------------------------------------------------------
+LE_SHARED void ifgen_admin_SetJsonOverride
+(
+    le_msg_SessionRef_t _ifgen_sessionRef,
+        const char* LE_NONNULL path,
+        ///< [IN] Absolute path of the resource.
+        const char* LE_NONNULL value
+        ///< [IN]
+);
+
+//--------------------------------------------------------------------------------------------------
+/**
+ * Find out whether the resource currently has an override set.
+ *
+ * @return true if the resource has an override, false otherwise.
+ *
+ * @note It's possible for an Input or Output to have an override set, but not be overridden.
+ *       This is because setting an override to a data type that does not match the Input or
+ *       Output resource's data type will result in the override being ignored.  Observations
+ *       (and Placeholders) have flexible data types, so if they have an override set, they will
+ *       definitely be overridden.
+ */
+//--------------------------------------------------------------------------------------------------
+LE_SHARED bool ifgen_admin_HasOverride
+(
+    le_msg_SessionRef_t _ifgen_sessionRef,
+        const char* LE_NONNULL path
+        ///< [IN] Absolute path of the resource.
+);
+
+//--------------------------------------------------------------------------------------------------
+/**
+ * Get the data type of the override value that is currently set on a given resource.
+ *
+ * @return The data type, or IO_DATA_TYPE_TRIGGER if not set.
+ */
+//--------------------------------------------------------------------------------------------------
+LE_SHARED io_DataType_t ifgen_admin_GetOverrideDataType
+(
+    le_msg_SessionRef_t _ifgen_sessionRef,
+        const char* LE_NONNULL path
+        ///< [IN] Absolute path of the resource.
+);
+
+//--------------------------------------------------------------------------------------------------
+/**
+ * Get the override value of a resource, if it is Boolean.
+ *
+ * @return the override value, or false if not set or set to another data type.
+ */
+//--------------------------------------------------------------------------------------------------
+LE_SHARED bool ifgen_admin_GetBooleanOverride
+(
+    le_msg_SessionRef_t _ifgen_sessionRef,
+        const char* LE_NONNULL path
+        ///< [IN] Absolute path of the resource.
+);
+
+//--------------------------------------------------------------------------------------------------
+/**
+ * Get the override value, if it is numeric.
+ *
+ * @return the override value, or NAN (not a number) if not set or set to another data type.
+ */
+//--------------------------------------------------------------------------------------------------
+LE_SHARED double ifgen_admin_GetNumericOverride
+(
+    le_msg_SessionRef_t _ifgen_sessionRef,
+        const char* LE_NONNULL path
+        ///< [IN] Absolute path of the resource.
+);
+
+//--------------------------------------------------------------------------------------------------
+/**
+ * Get the override value, if it is a string.
+ *
+ * @return
+ *  - LE_OK if successful,
+ *  - LE_OVERFLOW if the buffer provided is too small to hold the value.
+ *  - LE_NOT_FOUND if the resource doesn't have a string override value set.
+ */
+//--------------------------------------------------------------------------------------------------
+LE_SHARED le_result_t ifgen_admin_GetStringOverride
+(
+    le_msg_SessionRef_t _ifgen_sessionRef,
+        const char* LE_NONNULL path,
+        ///< [IN] Absolute path of the resource.
+        char* value,
+        ///< [OUT]
+        size_t valueSize
+        ///< [IN]
+);
+
+//--------------------------------------------------------------------------------------------------
+/**
+ * Get the override value, in JSON format.
+ *
+ * @note This works for any type of override value.
+ *
+ * @return
+ *  - LE_OK if successful,
+ *  - LE_OVERFLOW if the buffer provided is too small to hold the value.
+ *  - LE_NOT_FOUND if the resource doesn't have an override value set.
+ */
+//--------------------------------------------------------------------------------------------------
+LE_SHARED le_result_t ifgen_admin_GetJsonOverride
+(
+    le_msg_SessionRef_t _ifgen_sessionRef,
+        const char* LE_NONNULL path,
+        ///< [IN] Absolute path of the resource.
+        char* value,
+        ///< [OUT]
+        size_t valueSize
+        ///< [IN]
+);
+
+//--------------------------------------------------------------------------------------------------
+/**
+ * Remove any override on a given resource.
+ */
+//--------------------------------------------------------------------------------------------------
+LE_SHARED void ifgen_admin_RemoveOverride
+(
+    le_msg_SessionRef_t _ifgen_sessionRef,
+        const char* LE_NONNULL path
+        ///< [IN] Absolute path of the resource.
+);
+
+//--------------------------------------------------------------------------------------------------
+/**
+ * Get the name of the first child entry under a given parent entry in the resource tree.
+ *
+ * @return
+ *  - LE_OK if successful
+ *  - LE_OVERFLOW if the buffer provided is too small to hold the child's path.
+ *  - LE_NOT_FOUND if the resource doesn't have any children.
+ */
+//--------------------------------------------------------------------------------------------------
+LE_SHARED le_result_t ifgen_admin_GetFirstChild
+(
+    le_msg_SessionRef_t _ifgen_sessionRef,
+        const char* LE_NONNULL path,
+        ///< [IN] Absolute path of the resource.
+        char* child,
+        ///< [OUT] Absolute path of the first child resource.
+        size_t childSize
+        ///< [IN]
+);
+
+//--------------------------------------------------------------------------------------------------
+/**
+ * Get the name of the next child entry under the same parent as a given entry in the resource tree.
+ *
+ * @return
+ *  - LE_OK if successful
+ *  - LE_OVERFLOW if the buffer provided is too small to hold the next sibling's path.
+ *  - LE_NOT_FOUND if the resource is the last child in its parent's list of children.
+ */
+//--------------------------------------------------------------------------------------------------
+LE_SHARED le_result_t ifgen_admin_GetNextSibling
+(
+    le_msg_SessionRef_t _ifgen_sessionRef,
+        const char* LE_NONNULL path,
+        ///< [IN] Absolute path of the resource.
+        char* sibling,
+        ///< [OUT] Absolute path of the next sibling resource.
+        size_t siblingSize
+        ///< [IN]
+);
+
+//--------------------------------------------------------------------------------------------------
+/**
+ * Find out what type of entry lives at a given path in the resource tree.
+ *
+ * @return The entry type. ADMIN_ENTRY_TYPE_NONE if there's no entry at the given path.
+ */
+//--------------------------------------------------------------------------------------------------
+LE_SHARED admin_EntryType_t ifgen_admin_GetEntryType
+(
+    le_msg_SessionRef_t _ifgen_sessionRef,
+        const char* LE_NONNULL path
+        ///< [IN] Absolute path of the resource.
+);
+
+//--------------------------------------------------------------------------------------------------
+/**
+ * Check if a given resource is a mandatory output.  If so, it means that this is an output resource
+ * that must have a value before the related app function will begin working.
+ *
+ * @return true if a mandatory output, false if it's an optional output or not an output at all.
+ */
+//--------------------------------------------------------------------------------------------------
+LE_SHARED bool ifgen_admin_IsMandatory
+(
+    le_msg_SessionRef_t _ifgen_sessionRef,
+        const char* LE_NONNULL path
+        ///< [IN] Absolute path of the resource.
+);
+
+//--------------------------------------------------------------------------------------------------
+/**
+ * Add handler function for EVENT 'admin_ResourceTreeChange'
+ */
+//--------------------------------------------------------------------------------------------------
+LE_SHARED admin_ResourceTreeChangeHandlerRef_t ifgen_admin_AddResourceTreeChangeHandler
+(
+    le_msg_SessionRef_t _ifgen_sessionRef,
+        admin_ResourceTreeChangeHandlerFunc_t callbackPtr,
+        ///< [IN]
+        void* contextPtr
+        ///< [IN]
+);
+
+//--------------------------------------------------------------------------------------------------
+/**
+ * Remove handler function for EVENT 'admin_ResourceTreeChange'
+ */
+//--------------------------------------------------------------------------------------------------
+LE_SHARED void ifgen_admin_RemoveResourceTreeChangeHandler
+(
+    le_msg_SessionRef_t _ifgen_sessionRef,
+        admin_ResourceTreeChangeHandlerRef_t handlerRef
+        ///< [IN]
+);
+
+//--------------------------------------------------------------------------------------------------
+/**
+ * Signal to the Data Hub that administrative changes are about to be performed.
+ *
+ * This will result in call-backs to any handlers registered using io_AddUpdateStartEndHandler().
+ */
+//--------------------------------------------------------------------------------------------------
+LE_SHARED void ifgen_admin_StartUpdate
+(
+    le_msg_SessionRef_t _ifgen_sessionRef
+);
+
+//--------------------------------------------------------------------------------------------------
+/**
+ * Signal to the Data Hub that all pending administrative changes have been applied and that
+ * normal operation may resume.
+ *
+ * This may trigger clean-up actions, such as deleting non-volatile backups of any Observations
+ * that do not exist at the time this function is called.
+ *
+ * This will also result in call-backs to any handlers registered using
+ * io_AddUpdateStartEndHandler().
+ */
+//--------------------------------------------------------------------------------------------------
+LE_SHARED void ifgen_admin_EndUpdate
+(
+    le_msg_SessionRef_t _ifgen_sessionRef
+);
+
+#endif // ADMIN_COMMON_H_INCLUDE_GUARD

--- a/test/admin/admin_interface.h
+++ b/test/admin/admin_interface.h
@@ -1,4 +1,14 @@
 
+
+/*
+ * ====================== WARNING ======================
+ *
+ * THE CONTENTS OF THIS FILE HAVE BEEN AUTO-GENERATED.
+ * DO NOT MODIFY IN ANY WAY.
+ *
+ * ====================== WARNING ======================
+ */
+
 /**
  * @page c_dataHubAdmin Data Hub Admin API
  *
@@ -12,7 +22,6 @@
  *  - Setting and clearing overrides on resources
  *  - Setting the default values of resources
  *  - Pushing values to resources anywhere in the resource tree
- *  - Creating Input and Output resources
  *
  *
  * @section c_dataHubAdmin_ResTree The Resource Tree
@@ -30,9 +39,10 @@
  *  - Observation - filters and/or buffers data
  *  - Placeholder - a placeholder for a yet to be created resource
  *
- * Inputs and Outputs can be created by external apps using the @ref c_dataHubIo, or directly with
- * the @ref c_dataHubAdmin. The Inputs and Outputs created by a given app "x" reside under a
- * namespace "/app/x" that is reserved for that app.
+ * Inputs and Outputs are created by external apps using the @ref c_dataHubIo.  The Inputs and
+ * Outputs created by a given app "x" reside under a namespace "/app/x" that is reserved for that
+ * app.  See @ref c_dataHubIo for more information on the structure of these parts of the
+ * resource tree.
  *
  * Observations are created via the Admin API (this API; see below).
  *
@@ -485,188 +495,102 @@
  * there is no support built into this API for coordination between multiple clients.
  *
  *
- * @section c_dataHubAdmin_Resources I/O Resources
- *
- * Clients create Admin "resources" within the Data Hub's resource tree.  Time-stamped
- * data is "pushed" into the Data Hub via "Input" resources and can be received as output from
- * the Data Hub via "Output" resources.
- *
- * Configuration of the routing, filtering, and buffering of this data inside the Data Hub is
- * the responsibility of an "administrator" app, using the @ref c_dataHubAdmin.  Clients of the
- * Admin API don't care about where the data is routed and how it is processed.  They just create
- * their Input and Output resources and send and receive data through those.  This de-couples
- * the I/O apps from the rest of the system, allowing them to be reused in different ways within
- * different systems.
- *
- * Input resources (for pushing input to the Data Hub) are created using admin_CreateInput().
- *
- * Output resources (for receiving output from the Data Hub) are created using admin_CreateOutput().
- *
- * Both Input and Output resources can be deleted using admin_DeleteResource().
- *
- * @note A resource that has been deleted by the Admin API client app may still appear in the
- *       resource tree if the administrator has applied any settings to that resource. The
- *       resource will only disappear from the resource tree when all administrative settings have
- *       been removed *and* the app that created the resource has either deleted the resource or
- *       disconnected from the Data Hub.
- *
- * Each I/O resource has the following attributes:
- * - Path
- * - Data type
- * - Units
- *
- * @code
- *
- * le_result_t result = admin_CreateInput("temperature/value", IO_DATA_TYPE_NUMERIC, "degC");
- *
- * @endcode
- *
- *
- * @section c_dataHubAdmin_Paths Paths
- *
- * The path of a resource is its unique identifier within the Data Hub's resource tree.
- *
- * Admin API allows to create any I/O resource within any namespace.
- *
- * Path has to be absolute, eg. "/app/tempSensor/temperature/value".
- *
- * An important set of conventions exist for structuring I/O resource paths:
- * - A sensor's main input resource must be called "value".
- * - An actuator's main output resource must be called "enable".
- * - The name of the "value" or "enable" resource's parent is the name of the sensor or actuator.
- * - All output resources under the same parent as a "value" or "enable" resource are for related
- *   settings.
- *
- * Furthermore, some conventions exist for settings related to sensors:
- * - If a sensor has a boolean output resource called "enable" next to (under the same parent as)
- *   its "value" resource, that "enable" resource can be used by administrator apps to disable the
- *   sensor (by setting that output to "false").
- * - If a boolean output resource called "period" appears next to a "value" input resource
- *   then it can be used to tell the sensor to perform periodic sampling.
- * - If a trigger output resource called "trigger" appears next to a "value" input resource
- *   then it can be used to tell the sensor to push a single sample to its "value" input.
- *
- * For example,
- *
- * @verbatim
-/app
-  |
-  +--/airSensor
-  |   |
-  |   +--/temperature
-  |   |   |
-  |   |   +--/value = the temperature sensor input
-  |   |   |
-  |   |   +--/period = an output used to configure the temperature sensor's sampling period
-  |   |   |
-  |   |   +--/trigger = an output used to immediately trigger a single temperature sensor sample
-  |   |   |
-  |   |   +--/enable = an output used to enable or disable the temperature sensor
-  |   |
-  |   +--/humidity
-  |       |
-  |       +--/value = the humidity sensor input
-  |       |
-  |       +--/period = an output used to configure the humidity sensor's sampling period
-  |       |
-  |       +--/enable = an output used to enable or disable the humidity sensor
-  |
-  +--/lowBattery
-  |   |
-  |   +--/value = the lowBattery sensor input
-  |   |
-  |   +--/level = output used to configure the level at which the low battery alarm will trigger
-  |
-  +--/hvac
-      |
-      +--/temperature = the HVAC system's temperature setpoint output
-      |
-      +--/enable = an output used to enable or disable the HVAC system
-      |
-      +--/fanOn = an output used to control the fan mode (auto or always on)
-      |
-      +--/coolOff = an output used to control the cooling mode (auto or disabled)
-      |
-      +--/heatOff = an output used to control the heating mode (auto or disabled)
- * @endverbatim
- *
- * @note The @c enable output can be used to coordinate atomic updates to multiple output
- * resources for the same sensor or actuator.  For example, if an analog-to-digital converter (ADC)
- * accepts settings @c adc/min and @c adc/max to configure the scaling of the ADC reading into
- * physical units like "degC" or "%RH", the sensor may produce garbage readings between the time
- * that @c adc/min and @c adc/max are updated.  The sensor can then also provide @c adc/enable,
- * which the admin tool can use to disable the ADC while it is updating @c adc/min and @c adc/max.
- *
- * Paths are not permitted to contain '.', '[', or ']' characters, as those are reserved for
- * specifying members of structured JSON data samples in the @ref c_dataHubAdmin "Admin" and
- * @ref c_dataHubQuery "Query" APIs.
- *
- *
- * @section c_dataHubAdmin_DataTypes Data Types
- *
- * Data types supported are:
- * - trigger = used to indicate an event that doesn't have any associated value.
- * - Boolean = a Boolean (true or false) value
- * - numeric = a double-precision floating point value.
- * - string = a UTF-8 string value
- * - JSON = a string in JSON format
- *
- * JSON and string Inputs and Outputs can receive any type of data, but other types of
- * Input or Output can only receive one type of data.  E.g., a Boolean sample cannot
- * be pushed to a trigger or numeric resource, and a string cannot be pushed to a Boolean, trigger,
- * or numeric resource.
- *
- * Furthermore, JSON and string type push hander call-back functions can be registered on other
- * types of Outputs, and a type conversion will happen automatically when the data sample is
- * delivered to its consumer.  For example, if io_AddJsonPushHandler() is used to register a JSON
- * Push Handler call-back on a numeric Output, whenever a numeric data sample arrives at that
- * Output, the JSON push handler will be called with a string parameter containing the JSON
- * representation of that numeric sample's value.
- *
- * @subsection c_dataHubAdmin_DataTypes_JsonExamples JSON Examples
- *
- * When a JSON Input is created, admin_SetJsonExample() can be called to provide an example of what a
- * value should look like.  This can be retrieved by the administrative app via a call to
- * admin_GetJsonExample(), and allows the administrator to see (via an HMI of some kind) what a
- * value might look like before the sensor is enabled.  This assists in the configuration of
- * @ref c_dataHubAdmin_JsonExtraction "JSON extraction" before going live with data collection.
- *
- * @code
- *
- * admin_SetJsonExample("accel/value", "{\"x\": 0, \"y\": 0, \"z\": 0}");
- *
- * @endcode
- *
- *
- * @section c_dataHubAdmin_Units Units
- *
- * Scalar data values have units, such as degrees Celcius, Pascals, Hertz, etc.  Defects can arise
- * if the sender and receiver of a data sample disagree on their units.  For example,
- * https://en.wikipedia.org/wiki/Mars_Climate_Orbiter.
- *
- * When a numeric type I/O resource is created, it can have a string describing its units.
- * If two resources do not agree on their units, data samples will not be routed between them.
- *
- * See the senml RFC draft for a list of units strings in section 12.1 Units Registry at
- * https://tools.ietf.org/html/draft-ietf-core-senml-12#page-26.
- *
- *
  * Copyright (C) Sierra Wireless Inc.
  *
  * @file admin_interface.h
  */
+
+#ifndef ADMIN_INTERFACE_H_INCLUDE_GUARD
+#define ADMIN_INTERFACE_H_INCLUDE_GUARD
+
+
+#include "legato.h"
+
+// Interface specific includes
+#include "io_interface.h"
+
+// Internal includes for this interface
+#include "admin_common.h"
 //--------------------------------------------------------------------------------------------------
-
-
-USETYPES io.api;
-
+/**
+ * Type for handler called when a server disconnects.
+ */
+//--------------------------------------------------------------------------------------------------
+typedef void (*admin_DisconnectHandler_t)(void *);
 
 //--------------------------------------------------------------------------------------------------
 /**
- * Maximum number of characters in a JSON extraction specifier string (excluding null terminator).
+ *
+ * Connect the current client thread to the service providing this API. Block until the service is
+ * available.
+ *
+ * For each thread that wants to use this API, either ConnectService or TryConnectService must be
+ * called before any other functions in this API.  Normally, ConnectService is automatically called
+ * for the main thread, but not for any other thread. For details, see @ref apiFilesC_client.
+ *
+ * This function is created automatically.
  */
 //--------------------------------------------------------------------------------------------------
-DEFINE MAX_JSON_EXTRACTOR_LEN = 63;
+void admin_ConnectService
+(
+    void
+);
+
+//--------------------------------------------------------------------------------------------------
+/**
+ *
+ * Try to connect the current client thread to the service providing this API. Return with an error
+ * if the service is not available.
+ *
+ * For each thread that wants to use this API, either ConnectService or TryConnectService must be
+ * called before any other functions in this API.  Normally, ConnectService is automatically called
+ * for the main thread, but not for any other thread. For details, see @ref apiFilesC_client.
+ *
+ * This function is created automatically.
+ *
+ * @return
+ *  - LE_OK if the client connected successfully to the service.
+ *  - LE_UNAVAILABLE if the server is not currently offering the service to which the client is
+ *    bound.
+ *  - LE_NOT_PERMITTED if the client interface is not bound to any service (doesn't have a binding).
+ *  - LE_COMM_ERROR if the Service Directory cannot be reached.
+ */
+//--------------------------------------------------------------------------------------------------
+le_result_t admin_TryConnectService
+(
+    void
+);
+
+//--------------------------------------------------------------------------------------------------
+/**
+ * Set handler called when server disconnection is detected.
+ *
+ * When a server connection is lost, call this handler then exit with LE_FATAL.  If a program wants
+ * to continue without exiting, it should call longjmp() from inside the handler.
+ */
+//--------------------------------------------------------------------------------------------------
+LE_FULL_API void admin_SetServerDisconnectHandler
+(
+    admin_DisconnectHandler_t disconnectHandler,
+    void *contextPtr
+);
+
+//--------------------------------------------------------------------------------------------------
+/**
+ *
+ * Disconnect the current client thread from the service providing this API.
+ *
+ * Normally, this function doesn't need to be called. After this function is called, there's no
+ * longer a connection to the service, and the functions in this API can't be used. For details, see
+ * @ref apiFilesC_client.
+ *
+ * This function is created automatically.
+ */
+//--------------------------------------------------------------------------------------------------
+void admin_DisconnectService
+(
+    void
+);
 
 
 //--------------------------------------------------------------------------------------------------
@@ -674,15 +598,6 @@ DEFINE MAX_JSON_EXTRACTOR_LEN = 63;
  * Enumerates the different types of entries that can exist in the resource tree.
  */
 //--------------------------------------------------------------------------------------------------
-ENUM EntryType
-{
-    ENTRY_TYPE_NONE,        ///< Not an entry
-    ENTRY_TYPE_NAMESPACE,   ///< Namespace
-    ENTRY_TYPE_INPUT,       ///< Input
-    ENTRY_TYPE_OUTPUT,      ///< Output
-    ENTRY_TYPE_OBSERVATION, ///< Observation
-    ENTRY_TYPE_PLACEHOLDER  ///< Placeholder
-};
 
 
 //--------------------------------------------------------------------------------------------------
@@ -690,19 +605,6 @@ ENUM EntryType
  * Enumerates the different operations on a Resource - add and remove.
  */
 //--------------------------------------------------------------------------------------------------
-ENUM ResourceOperationType
-{
-    RESOURCE_ADDED,     //< Added
-    RESOURCE_REMOVED    //< Removed
-};
-
-
-//--------------------------------------------------------------------------------------------------
-/**
- * Maximum number of optional transform parameters for an observation buffer.
- */
-//--------------------------------------------------------------------------------------------------
-DEFINE MAX_TRANSFORM_PARAMETERS = 8;
 
 
 //--------------------------------------------------------------------------------------------------
@@ -710,14 +612,91 @@ DEFINE MAX_TRANSFORM_PARAMETERS = 8;
  * Enumerates the different types of transforms which can be applied to an observation buffer
  */
 //--------------------------------------------------------------------------------------------------
-ENUM TransformType
-{
-    OBS_TRANSFORM_TYPE_NONE,      ///< No transformation
-    OBS_TRANSFORM_TYPE_MEAN,      ///< Mean
-    OBS_TRANSFORM_TYPE_STDDEV,    ///< Standard Deviation
-    OBS_TRANSFORM_TYPE_MAX,       ///< Maximum value in buffer
-    OBS_TRANSFORM_TYPE_MIN,       ///< Minimum value in buffer
-};
+
+
+//--------------------------------------------------------------------------------------------------
+/**
+ * Callback function for pushing triggers to an output
+ */
+//--------------------------------------------------------------------------------------------------
+
+
+//--------------------------------------------------------------------------------------------------
+/**
+ * Reference type used by Add/Remove functions for EVENT 'admin_TriggerPush'
+ */
+//--------------------------------------------------------------------------------------------------
+
+
+//--------------------------------------------------------------------------------------------------
+/**
+ * Callback function for pushing Boolean values to an output
+ */
+//--------------------------------------------------------------------------------------------------
+
+
+//--------------------------------------------------------------------------------------------------
+/**
+ * Reference type used by Add/Remove functions for EVENT 'admin_BooleanPush'
+ */
+//--------------------------------------------------------------------------------------------------
+
+
+//--------------------------------------------------------------------------------------------------
+/**
+ * Callback function for pushing numeric values to an output
+ */
+//--------------------------------------------------------------------------------------------------
+
+
+//--------------------------------------------------------------------------------------------------
+/**
+ * Reference type used by Add/Remove functions for EVENT 'admin_NumericPush'
+ */
+//--------------------------------------------------------------------------------------------------
+
+
+//--------------------------------------------------------------------------------------------------
+/**
+ * Callback function for pushing string values to an output
+ */
+//--------------------------------------------------------------------------------------------------
+
+
+//--------------------------------------------------------------------------------------------------
+/**
+ * Reference type used by Add/Remove functions for EVENT 'admin_StringPush'
+ */
+//--------------------------------------------------------------------------------------------------
+
+
+//--------------------------------------------------------------------------------------------------
+/**
+ * Callback function for pushing JSON values to an output
+ */
+//--------------------------------------------------------------------------------------------------
+
+
+//--------------------------------------------------------------------------------------------------
+/**
+ * Reference type used by Add/Remove functions for EVENT 'admin_JsonPush'
+ */
+//--------------------------------------------------------------------------------------------------
+
+
+//--------------------------------------------------------------------------------------------------
+/**
+ * Register a handler, to be called back whenever a Resource is added or removed
+ */
+//--------------------------------------------------------------------------------------------------
+
+
+//--------------------------------------------------------------------------------------------------
+/**
+ * Reference type used by Add/Remove functions for EVENT 'admin_ResourceTreeChange'
+ */
+//--------------------------------------------------------------------------------------------------
+
 
 //--------------------------------------------------------------------------------------------------
 /**
@@ -729,16 +708,17 @@ ENUM TransformType
  *  - LE_OK if successful.
  *  - LE_DUPLICATE if a resource by that name exists but with different direction, type or units.
  *  - LE_NO_MEMORY if the client is not permitted to create that many resources.
- *  - LE_FAULT if the path is not absolute.
  */
 //--------------------------------------------------------------------------------------------------
-FUNCTION le_result_t CreateInput
+le_result_t admin_CreateInput
 (
-    string path[io.MAX_RESOURCE_PATH_LEN] IN,///< Absolute resource tree path.
-    io.DataType dataType IN, ///< The data type.
-    string units[io.MAX_UNITS_NAME_LEN] IN ///< e.g., "degC" (see senml); "" = unspecified.
+    const char* LE_NONNULL path,
+        ///< [IN] Absolute resource tree path.
+    io_DataType_t dataType,
+        ///< [IN] The data type.
+    const char* LE_NONNULL units
+        ///< [IN] e.g., "degC" (see senml); "" = unspecified.
 );
-
 
 //--------------------------------------------------------------------------------------------------
 /**
@@ -747,12 +727,13 @@ FUNCTION le_result_t CreateInput
  * Does nothing if the resource is not found, is not an input, or doesn't have a JSON type.
  */
 //--------------------------------------------------------------------------------------------------
-FUNCTION SetJsonExample
+void admin_SetJsonExample
 (
-    string path[io.MAX_RESOURCE_PATH_LEN] IN,///< Absolute resource tree path.
-    string example[io.MAX_STRING_VALUE_LEN] IN ///< The example JSON value string.
+    const char* LE_NONNULL path,
+        ///< [IN] Absolute resource tree path.
+    const char* LE_NONNULL example
+        ///< [IN] The example JSON value string.
 );
-
 
 //--------------------------------------------------------------------------------------------------
 /**
@@ -764,16 +745,17 @@ FUNCTION SetJsonExample
  *  - LE_OK if successful.
  *  - LE_DUPLICATE if a resource by that name exists but with different direction, type or units.
  *  - LE_NO_MEMORY if the client is not permitted to create that many resources.
- *  - LE_FAULT if the path is not absolute.
  */
 //--------------------------------------------------------------------------------------------------
-FUNCTION le_result_t CreateOutput
+le_result_t admin_CreateOutput
 (
-    string path[io.MAX_RESOURCE_PATH_LEN] IN,///< Absolute resource tree path.
-    io.DataType dataType IN, ///< The data type.
-    string units[io.MAX_UNITS_NAME_LEN] IN ///< e.g., "degC" (see senml); "" = unspecified.
+    const char* LE_NONNULL path,
+        ///< [IN] Absolute resource tree path.
+    io_DataType_t dataType,
+        ///< [IN] The data type.
+    const char* LE_NONNULL units
+        ///< [IN] e.g., "degC" (see senml); "" = unspecified.
 );
-
 
 //--------------------------------------------------------------------------------------------------
 /**
@@ -782,9 +764,10 @@ FUNCTION le_result_t CreateOutput
  * Does nothing if the resource doesn't exist.
  */
 //--------------------------------------------------------------------------------------------------
-FUNCTION DeleteResource
+void admin_DeleteResource
 (
-    string path[io.MAX_RESOURCE_PATH_LEN] IN ///< Absolute resource tree path.
+    const char* LE_NONNULL path
+        ///< [IN] Absolute resource tree path.
 );
 
 //--------------------------------------------------------------------------------------------------
@@ -792,9 +775,10 @@ FUNCTION DeleteResource
  * Mark an Output resource "optional".  (By default, they are marked "mandatory".)
  */
 //--------------------------------------------------------------------------------------------------
-FUNCTION MarkOptional
+void admin_MarkOptional
 (
-    string path[io.MAX_RESOURCE_PATH_LEN] IN ///< Absolute resource tree path.
+    const char* LE_NONNULL path
+        ///< [IN] Absolute resource tree path.
 );
 
 //--------------------------------------------------------------------------------------------------
@@ -805,13 +789,14 @@ FUNCTION MarkOptional
  *       Placeholder resource to be created.
  */
 //--------------------------------------------------------------------------------------------------
-FUNCTION PushTrigger
+void admin_PushTrigger
 (
-    string path[io.MAX_RESOURCE_PATH_LEN] IN,///< Absolute resource tree path.
-    double timestamp IN ///< Timestamp in seconds since the Epoch 1970-01-01 00:00:00 +0000 (UTC).
-                        ///< Zero = now (i.e., generate a timestamp for me).
+    const char* LE_NONNULL path,
+        ///< [IN] Absolute resource tree path.
+    double timestamp
+        ///< [IN] Timestamp in seconds since the Epoch 1970-01-01 00:00:00 +0000 (UTC).
+        ///< Zero = now (i.e., generate a timestamp for me).
 );
-
 
 //--------------------------------------------------------------------------------------------------
 /**
@@ -821,14 +806,16 @@ FUNCTION PushTrigger
  *       Placeholder resource to be created.
  */
 //--------------------------------------------------------------------------------------------------
-FUNCTION PushBoolean
+void admin_PushBoolean
 (
-    string path[io.MAX_RESOURCE_PATH_LEN] IN,///< Absolute resource tree path.
-    double timestamp IN,///< Timestamp in seconds since the Epoch 1970-01-01 00:00:00 +0000 (UTC).
-                        ///< Zero = now (i.e., generate a timestamp for me).
-    bool value IN
+    const char* LE_NONNULL path,
+        ///< [IN] Absolute resource tree path.
+    double timestamp,
+        ///< [IN] Timestamp in seconds since the Epoch 1970-01-01 00:00:00 +0000 (UTC).
+        ///< Zero = now (i.e., generate a timestamp for me).
+    bool value
+        ///< [IN]
 );
-
 
 //--------------------------------------------------------------------------------------------------
 /**
@@ -838,14 +825,16 @@ FUNCTION PushBoolean
  *       Placeholder resource to be created.
  */
 //--------------------------------------------------------------------------------------------------
-FUNCTION PushNumeric
+void admin_PushNumeric
 (
-    string path[io.MAX_RESOURCE_PATH_LEN] IN,///< Absolute resource tree path.
-    double timestamp IN,///< Timestamp in seconds since the Epoch 1970-01-01 00:00:00 +0000 (UTC).
-                        ///< Zero = now (i.e., generate a timestamp for me).
-    double value IN
+    const char* LE_NONNULL path,
+        ///< [IN] Absolute resource tree path.
+    double timestamp,
+        ///< [IN] Timestamp in seconds since the Epoch 1970-01-01 00:00:00 +0000 (UTC).
+        ///< Zero = now (i.e., generate a timestamp for me).
+    double value
+        ///< [IN]
 );
-
 
 //--------------------------------------------------------------------------------------------------
 /**
@@ -855,14 +844,16 @@ FUNCTION PushNumeric
  *       Placeholder resource to be created.
  */
 //--------------------------------------------------------------------------------------------------
-FUNCTION PushString
+void admin_PushString
 (
-    string path[io.MAX_RESOURCE_PATH_LEN] IN,///< Absolute resource tree path.
-    double timestamp IN,///< Timestamp in seconds since the Epoch 1970-01-01 00:00:00 +0000 (UTC).
-                        ///< Zero = now (i.e., generate a timestamp for me).
-    string value[io.MAX_STRING_VALUE_LEN] IN
+    const char* LE_NONNULL path,
+        ///< [IN] Absolute resource tree path.
+    double timestamp,
+        ///< [IN] Timestamp in seconds since the Epoch 1970-01-01 00:00:00 +0000 (UTC).
+        ///< Zero = now (i.e., generate a timestamp for me).
+    const char* LE_NONNULL value
+        ///< [IN]
 );
-
 
 //--------------------------------------------------------------------------------------------------
 /**
@@ -872,135 +863,146 @@ FUNCTION PushString
  *       Placeholder resource to be created.
  */
 //--------------------------------------------------------------------------------------------------
-FUNCTION PushJson
+void admin_PushJson
 (
-    string path[io.MAX_RESOURCE_PATH_LEN] IN,///< Absolute resource tree path.
-    double timestamp IN,///< Timestamp in seconds since the Epoch 1970-01-01 00:00:00 +0000 (UTC).
-                        ///< Zero = now (i.e., generate a timestamp for me).
-    string value[io.MAX_STRING_VALUE_LEN] IN
+    const char* LE_NONNULL path,
+        ///< [IN] Absolute resource tree path.
+    double timestamp,
+        ///< [IN] Timestamp in seconds since the Epoch 1970-01-01 00:00:00 +0000 (UTC).
+        ///< Zero = now (i.e., generate a timestamp for me).
+    const char* LE_NONNULL value
+        ///< [IN]
 );
-
 
 //--------------------------------------------------------------------------------------------------
 /**
- * Callback function for pushing triggers to an output
+ * Add handler function for EVENT 'admin_TriggerPush'
  */
 //--------------------------------------------------------------------------------------------------
-HANDLER TriggerPushHandler
+admin_TriggerPushHandlerRef_t admin_AddTriggerPushHandler
 (
-    double timestamp IN ///< Timestamp in seconds since the Epoch 1970-01-01 00:00:00 +0000 (UTC).
+    const char* LE_NONNULL path,
+        ///< [IN] Absolute path of resource.
+    admin_TriggerPushHandlerFunc_t callbackPtr,
+        ///< [IN]
+    void* contextPtr
+        ///< [IN]
 );
-
-
-//--------------------------------------------------------------------------------------------------
-/*
- * Causes the AddTriggerPushHandler() and RemoveTriggerPushHandler() functions
- * to be generated by the Legato build tools.
- */
-//--------------------------------------------------------------------------------------------------
-EVENT TriggerPush
-(
-    string path[io.MAX_RESOURCE_PATH_LEN] IN,///< Absolute path of resource.
-    TriggerPushHandler callback
-);
-
 
 //--------------------------------------------------------------------------------------------------
 /**
- * Callback function for pushing Boolean values to an output
+ * Remove handler function for EVENT 'admin_TriggerPush'
  */
 //--------------------------------------------------------------------------------------------------
-HANDLER BooleanPushHandler
+void admin_RemoveTriggerPushHandler
 (
-    double timestamp IN,///< Timestamp in seconds since the Epoch 1970-01-01 00:00:00 +0000 (UTC).
-    bool value IN
+    admin_TriggerPushHandlerRef_t handlerRef
+        ///< [IN]
 );
-
-
-//--------------------------------------------------------------------------------------------------
-/*
- * Causes the AddBooleanPushHandler() and RemoveBooleanPushHandler() functions
- * to be generated by the Legato build tools.
- */
-//--------------------------------------------------------------------------------------------------
-EVENT BooleanPush
-(
-    string path[io.MAX_RESOURCE_PATH_LEN] IN,///< Absolute path of resource.
-    BooleanPushHandler callback
-);
-
 
 //--------------------------------------------------------------------------------------------------
 /**
- * Callback function for pushing numeric values to an output
+ * Add handler function for EVENT 'admin_BooleanPush'
  */
 //--------------------------------------------------------------------------------------------------
-HANDLER NumericPushHandler
+admin_BooleanPushHandlerRef_t admin_AddBooleanPushHandler
 (
-    double timestamp IN,///< Timestamp in seconds since the Epoch 1970-01-01 00:00:00 +0000 (UTC).
-    double value IN
+    const char* LE_NONNULL path,
+        ///< [IN] Absolute path of resource.
+    admin_BooleanPushHandlerFunc_t callbackPtr,
+        ///< [IN]
+    void* contextPtr
+        ///< [IN]
 );
-
-//--------------------------------------------------------------------------------------------------
-/*
- * Causes the AddNumericPushHandler() and RemoveNumericPushHandler() functions
- * to be generated by the Legato build tools.
- */
-//--------------------------------------------------------------------------------------------------
-EVENT NumericPush
-(
-    string path[io.MAX_RESOURCE_PATH_LEN] IN,///< Absolute path of resource.
-    NumericPushHandler callback
-);
-
 
 //--------------------------------------------------------------------------------------------------
 /**
- * Callback function for pushing string values to an output
+ * Remove handler function for EVENT 'admin_BooleanPush'
  */
 //--------------------------------------------------------------------------------------------------
-HANDLER StringPushHandler
+void admin_RemoveBooleanPushHandler
 (
-    double timestamp IN,///< Timestamp in seconds since the Epoch 1970-01-01 00:00:00 +0000 (UTC).
-    string value[io.MAX_STRING_VALUE_LEN] IN
+    admin_BooleanPushHandlerRef_t handlerRef
+        ///< [IN]
 );
-
-//--------------------------------------------------------------------------------------------------
-/*
- * Causes the AddStringPushHandler() and RemoveStringPushHandler() functions
- * to be generated by the Legato build tools.
- */
-//--------------------------------------------------------------------------------------------------
-EVENT StringPush
-(
-    string path[io.MAX_RESOURCE_PATH_LEN] IN,///< Absolute path of resource.
-    StringPushHandler callback
-);
-
 
 //--------------------------------------------------------------------------------------------------
 /**
- * Callback function for pushing JSON values to an output
+ * Add handler function for EVENT 'admin_NumericPush'
  */
 //--------------------------------------------------------------------------------------------------
-HANDLER JsonPushHandler
+admin_NumericPushHandlerRef_t admin_AddNumericPushHandler
 (
-    double timestamp IN,///< Timestamp in seconds since the Epoch 1970-01-01 00:00:00 +0000 (UTC).
-    string value[io.MAX_STRING_VALUE_LEN] IN
+    const char* LE_NONNULL path,
+        ///< [IN] Absolute path of resource.
+    admin_NumericPushHandlerFunc_t callbackPtr,
+        ///< [IN]
+    void* contextPtr
+        ///< [IN]
 );
 
 //--------------------------------------------------------------------------------------------------
-/*
- * Causes the AddJsonPushHandler() and RemoveJsonPushHandler() functions
- * to be generated by the Legato build tools.
+/**
+ * Remove handler function for EVENT 'admin_NumericPush'
  */
 //--------------------------------------------------------------------------------------------------
-EVENT JsonPush
+void admin_RemoveNumericPushHandler
 (
-    string path[io.MAX_RESOURCE_PATH_LEN] IN,///< Absolute path of resource.
-    JsonPushHandler callback
+    admin_NumericPushHandlerRef_t handlerRef
+        ///< [IN]
 );
 
+//--------------------------------------------------------------------------------------------------
+/**
+ * Add handler function for EVENT 'admin_StringPush'
+ */
+//--------------------------------------------------------------------------------------------------
+admin_StringPushHandlerRef_t admin_AddStringPushHandler
+(
+    const char* LE_NONNULL path,
+        ///< [IN] Absolute path of resource.
+    admin_StringPushHandlerFunc_t callbackPtr,
+        ///< [IN]
+    void* contextPtr
+        ///< [IN]
+);
+
+//--------------------------------------------------------------------------------------------------
+/**
+ * Remove handler function for EVENT 'admin_StringPush'
+ */
+//--------------------------------------------------------------------------------------------------
+void admin_RemoveStringPushHandler
+(
+    admin_StringPushHandlerRef_t handlerRef
+        ///< [IN]
+);
+
+//--------------------------------------------------------------------------------------------------
+/**
+ * Add handler function for EVENT 'admin_JsonPush'
+ */
+//--------------------------------------------------------------------------------------------------
+admin_JsonPushHandlerRef_t admin_AddJsonPushHandler
+(
+    const char* LE_NONNULL path,
+        ///< [IN] Absolute path of resource.
+    admin_JsonPushHandlerFunc_t callbackPtr,
+        ///< [IN]
+    void* contextPtr
+        ///< [IN]
+);
+
+//--------------------------------------------------------------------------------------------------
+/**
+ * Remove handler function for EVENT 'admin_JsonPush'
+ */
+//--------------------------------------------------------------------------------------------------
+void admin_RemoveJsonPushHandler
+(
+    admin_JsonPushHandlerRef_t handlerRef
+        ///< [IN]
+);
 
 //--------------------------------------------------------------------------------------------------
 /**
@@ -1022,12 +1024,13 @@ EVENT JsonPush
  *  - LE_DUPLICATE if the addition of this route would result in a loop.
  */
 //--------------------------------------------------------------------------------------------------
-FUNCTION le_result_t SetSource
+le_result_t admin_SetSource
 (
-    string destPath[io.MAX_RESOURCE_PATH_LEN] IN, ///< Absolute path of destination resource.
-    string srcPath[io.MAX_RESOURCE_PATH_LEN] IN  ///< Absolute path of source resource.
+    const char* LE_NONNULL destPath,
+        ///< [IN] Absolute path of destination resource.
+    const char* LE_NONNULL srcPath
+        ///< [IN] Absolute path of source resource.
 );
-
 
 //--------------------------------------------------------------------------------------------------
 /**
@@ -1046,23 +1049,26 @@ FUNCTION le_result_t SetSource
  *  - LE_OVERFLOW if the path of the source resource won't fit in the string buffer provided.
  */
 //--------------------------------------------------------------------------------------------------
-FUNCTION le_result_t GetSource
+le_result_t admin_GetSource
 (
-    string destPath[io.MAX_RESOURCE_PATH_LEN] IN, ///< Absolute path of destination resource.
-    string srcPath[io.MAX_RESOURCE_PATH_LEN] OUT  ///< Absolute path of source resource.
+    const char* LE_NONNULL destPath,
+        ///< [IN] Absolute path of destination resource.
+    char* srcPath,
+        ///< [OUT] Absolute path of source resource.
+    size_t srcPathSize
+        ///< [IN]
 );
-
 
 //--------------------------------------------------------------------------------------------------
 /**
  * Remove the data flow route into a resource.
  */
 //--------------------------------------------------------------------------------------------------
-FUNCTION RemoveSource
+void admin_RemoveSource
 (
-    string destPath[io.MAX_RESOURCE_PATH_LEN] IN  ///< Absolute path of destination resource.
+    const char* LE_NONNULL destPath
+        ///< [IN] Absolute path of destination resource.
 );
-
 
 //--------------------------------------------------------------------------------------------------
 /**
@@ -1073,22 +1079,22 @@ FUNCTION RemoveSource
  *  - LE_BAD_PARAMETER if the path is invalid.
  */
 //--------------------------------------------------------------------------------------------------
-FUNCTION le_result_t CreateObs
+le_result_t admin_CreateObs
 (
-    string path[io.MAX_RESOURCE_PATH_LEN] IN  ///< Path within the /obs/ namespace.
+    const char* LE_NONNULL path
+        ///< [IN] Path within the /obs/ namespace.
 );
-
 
 //--------------------------------------------------------------------------------------------------
 /**
  * Delete an Observation in the /obs/ namespace.
  */
 //--------------------------------------------------------------------------------------------------
-FUNCTION DeleteObs
+void admin_DeleteObs
 (
-    string path[io.MAX_RESOURCE_PATH_LEN] IN  ///< Path within the /obs/ namespace.
+    const char* LE_NONNULL path
+        ///< [IN] Path within the /obs/ namespace.
 );
-
 
 //--------------------------------------------------------------------------------------------------
 /**
@@ -1097,12 +1103,13 @@ FUNCTION DeleteObs
  * This is used to throttle the rate of data passing into and through an Observation.
  */
 //--------------------------------------------------------------------------------------------------
-FUNCTION SetMinPeriod
+void admin_SetMinPeriod
 (
-    string path[io.MAX_RESOURCE_PATH_LEN] IN, ///< Path within the /obs/ namespace.
-    double minPeriod IN ///< The minimum period, in seconds.
+    const char* LE_NONNULL path,
+        ///< [IN] Path within the /obs/ namespace.
+    double minPeriod
+        ///< [IN] The minimum period, in seconds.
 );
-
 
 //--------------------------------------------------------------------------------------------------
 /**
@@ -1111,11 +1118,11 @@ FUNCTION SetMinPeriod
  * @return The value, or NAN (not a number) if not set.
  */
 //--------------------------------------------------------------------------------------------------
-FUNCTION double GetMinPeriod
+double admin_GetMinPeriod
 (
-    string path[io.MAX_RESOURCE_PATH_LEN] IN  ///< Path within the /obs/ namespace.
+    const char* LE_NONNULL path
+        ///< [IN] Path within the /obs/ namespace.
 );
-
 
 //--------------------------------------------------------------------------------------------------
 /**
@@ -1124,12 +1131,13 @@ FUNCTION double GetMinPeriod
  * Ignored for all non-numeric types except Boolean for which non-zero = true and zero = false.
  */
 //--------------------------------------------------------------------------------------------------
-FUNCTION SetHighLimit
+void admin_SetHighLimit
 (
-    string path[io.MAX_RESOURCE_PATH_LEN] IN, ///< Path within the /obs/ namespace.
-    double highLimit IN ///< The highest value in the range, or NAN (not a number) to remove limit.
+    const char* LE_NONNULL path,
+        ///< [IN] Path within the /obs/ namespace.
+    double highLimit
+        ///< [IN] The highest value in the range, or NAN (not a number) to remove limit.
 );
-
 
 //--------------------------------------------------------------------------------------------------
 /**
@@ -1138,11 +1146,11 @@ FUNCTION SetHighLimit
  * @return The value, or NAN (not a number) if not set.
  */
 //--------------------------------------------------------------------------------------------------
-FUNCTION double GetHighLimit
+double admin_GetHighLimit
 (
-    string path[io.MAX_RESOURCE_PATH_LEN] IN  ///< Path within the /obs/ namespace.
+    const char* LE_NONNULL path
+        ///< [IN] Path within the /obs/ namespace.
 );
-
 
 //--------------------------------------------------------------------------------------------------
 /**
@@ -1151,12 +1159,13 @@ FUNCTION double GetHighLimit
  * Ignored for all non-numeric types except Boolean for which non-zero = true and zero = false.
  */
 //--------------------------------------------------------------------------------------------------
-FUNCTION SetLowLimit
+void admin_SetLowLimit
 (
-    string path[io.MAX_RESOURCE_PATH_LEN] IN, ///< Path within the /obs/ namespace.
-    double lowLimit IN ///< The lowest value in the range, or NAN (not a number) to remove limit.
+    const char* LE_NONNULL path,
+        ///< [IN] Path within the /obs/ namespace.
+    double lowLimit
+        ///< [IN] The lowest value in the range, or NAN (not a number) to remove limit.
 );
-
 
 //--------------------------------------------------------------------------------------------------
 /**
@@ -1165,11 +1174,11 @@ FUNCTION SetLowLimit
  * @return The value, or NAN (not a number) if not set.
  */
 //--------------------------------------------------------------------------------------------------
-FUNCTION double GetLowLimit
+double admin_GetLowLimit
 (
-    string path[io.MAX_RESOURCE_PATH_LEN] IN  ///< Path within the /obs/ namespace.
+    const char* LE_NONNULL path
+        ///< [IN] Path within the /obs/ namespace.
 );
-
 
 //--------------------------------------------------------------------------------------------------
 /**
@@ -1181,12 +1190,13 @@ FUNCTION double GetLowLimit
  * For all other types, any non-zero value means accept any change, but drop if the same as current.
  */
 //--------------------------------------------------------------------------------------------------
-FUNCTION SetChangeBy
+void admin_SetChangeBy
 (
-    string path[io.MAX_RESOURCE_PATH_LEN] IN, ///< Path within the /obs/ namespace.
-    double change IN ///< The magnitude, or either zero or NAN (not a number) to remove limit.
+    const char* LE_NONNULL path,
+        ///< [IN] Path within the /obs/ namespace.
+    double change
+        ///< [IN] The magnitude, or either zero or NAN (not a number) to remove limit.
 );
-
 
 //--------------------------------------------------------------------------------------------------
 /**
@@ -1196,11 +1206,11 @@ FUNCTION SetChangeBy
  * @return The value, or NAN (not a number) if not set.
  */
 //--------------------------------------------------------------------------------------------------
-FUNCTION double GetChangeBy
+double admin_GetChangeBy
 (
-    string path[io.MAX_RESOURCE_PATH_LEN] IN  ///< Path within the /obs/ namespace.
+    const char* LE_NONNULL path
+        ///< [IN] Path within the /obs/ namespace.
 );
-
 
 //--------------------------------------------------------------------------------------------------
 /**
@@ -1210,13 +1220,17 @@ FUNCTION double GetChangeBy
  * Ignored for all non-numeric types except Boolean for which non-zero = true and zero = false.
  */
 //--------------------------------------------------------------------------------------------------
-FUNCTION SetTransform
+void admin_SetTransform
 (
-    string path[io.MAX_RESOURCE_PATH_LEN] IN,   ///< Path within the /obs/ namespace.
-    TransformType transformType IN,             ///< Type of transform to apply
-    double params[MAX_TRANSFORM_PARAMETERS] IN  ///< Optional parameter list
+    const char* LE_NONNULL path,
+        ///< [IN] Path within the /obs/ namespace.
+    admin_TransformType_t transformType,
+        ///< [IN] Type of transform to apply
+    const double* paramsPtr,
+        ///< [IN] Optional parameter list
+    size_t paramsSize
+        ///< [IN]
 );
-
 
 //--------------------------------------------------------------------------------------------------
 /**
@@ -1225,11 +1239,11 @@ FUNCTION SetTransform
  * @return The TransformType
  */
 //--------------------------------------------------------------------------------------------------
-FUNCTION TransformType GetTransform
+admin_TransformType_t admin_GetTransform
 (
-    string path[io.MAX_RESOURCE_PATH_LEN] IN   ///< Path within the /obs/ namespace.
+    const char* LE_NONNULL path
+        ///< [IN] Path within the /obs/ namespace.
 );
-
 
 //--------------------------------------------------------------------------------------------------
 /**
@@ -1242,12 +1256,13 @@ FUNCTION TransformType GetTransform
  * To clear, set to an empty string.
  */
 //--------------------------------------------------------------------------------------------------
-FUNCTION SetJsonExtraction
+void admin_SetJsonExtraction
 (
-    string path[io.MAX_RESOURCE_PATH_LEN] IN, ///< Path within the /obs/ namespace.
-    string extractionSpec[MAX_JSON_EXTRACTOR_LEN] IN ///< str specifying member/element to extract.
+    const char* LE_NONNULL path,
+        ///< [IN] Path within the /obs/ namespace.
+    const char* LE_NONNULL extractionSpec
+        ///< [IN] str specifying member/element to extract.
 );
-
 
 //--------------------------------------------------------------------------------------------------
 /**
@@ -1260,12 +1275,15 @@ FUNCTION SetJsonExtraction
  *  - LE_OVERFLOW if the JSON extraction specifier won't fit in the string buffer provided.
  */
 //--------------------------------------------------------------------------------------------------
-FUNCTION le_result_t GetJsonExtraction
+le_result_t admin_GetJsonExtraction
 (
-    string path[io.MAX_RESOURCE_PATH_LEN] IN,  ///< Path within the /obs/ namespace.
-    string result[MAX_JSON_EXTRACTOR_LEN] OUT  ///< Buffer where result goes if LE_OK returned.
+    const char* LE_NONNULL path,
+        ///< [IN] Path within the /obs/ namespace.
+    char* result,
+        ///< [OUT] Buffer where result goes if LE_OK returned.
+    size_t resultSize
+        ///< [IN]
 );
-
 
 //--------------------------------------------------------------------------------------------------
 /**
@@ -1273,12 +1291,13 @@ FUNCTION le_result_t GetJsonExtraction
  * circular buffers. When full, the buffer drops the oldest value to make room for a new addition.
  */
 //--------------------------------------------------------------------------------------------------
-FUNCTION SetBufferMaxCount
+void admin_SetBufferMaxCount
 (
-    string path[io.MAX_RESOURCE_PATH_LEN] IN, ///< Path within the /obs/ namespace.
-    uint32 count IN ///< The number of samples to buffer (0 = remove setting).
+    const char* LE_NONNULL path,
+        ///< [IN] Path within the /obs/ namespace.
+    uint32_t count
+        ///< [IN] The number of samples to buffer (0 = remove setting).
 );
-
 
 //--------------------------------------------------------------------------------------------------
 /**
@@ -1287,11 +1306,11 @@ FUNCTION SetBufferMaxCount
  * @return The buffer size (in number of samples) or 0 if not set or the Observation does not exist.
  */
 //--------------------------------------------------------------------------------------------------
-FUNCTION uint32 GetBufferMaxCount
+uint32_t admin_GetBufferMaxCount
 (
-    string path[io.MAX_RESOURCE_PATH_LEN] IN  ///< Path within the /obs/ namespace.
+    const char* LE_NONNULL path
+        ///< [IN] Path within the /obs/ namespace.
 );
-
 
 //--------------------------------------------------------------------------------------------------
 /**
@@ -1301,12 +1320,13 @@ FUNCTION uint32 GetBufferMaxCount
  * specifies.
  */
 //--------------------------------------------------------------------------------------------------
-FUNCTION SetBufferBackupPeriod
+void admin_SetBufferBackupPeriod
 (
-    string path[io.MAX_RESOURCE_PATH_LEN] IN, ///< Path within the /obs/ namespace.
-    uint32 seconds IN ///< The minimum number of seconds between backups (0 = disable backups)
+    const char* LE_NONNULL path,
+        ///< [IN] Path within the /obs/ namespace.
+    uint32_t seconds
+        ///< [IN] The minimum number of seconds between backups (0 = disable backups)
 );
-
 
 //--------------------------------------------------------------------------------------------------
 /**
@@ -1317,59 +1337,63 @@ FUNCTION SetBufferBackupPeriod
  *         does not exist.
  */
 //--------------------------------------------------------------------------------------------------
-FUNCTION uint32 GetBufferBackupPeriod
+uint32_t admin_GetBufferBackupPeriod
 (
-    string path[io.MAX_RESOURCE_PATH_LEN] IN  ///< Path within the /obs/ namespace.
+    const char* LE_NONNULL path
+        ///< [IN] Path within the /obs/ namespace.
 );
-
 
 //--------------------------------------------------------------------------------------------------
 /**
  * Set the default value of a resource to a Boolean value.
  */
 //--------------------------------------------------------------------------------------------------
-FUNCTION SetBooleanDefault
+void admin_SetBooleanDefault
 (
-    string path[io.MAX_RESOURCE_PATH_LEN] IN, ///< Absolute path of the resource.
-    bool value IN
+    const char* LE_NONNULL path,
+        ///< [IN] Absolute path of the resource.
+    bool value
+        ///< [IN]
 );
-
 
 //--------------------------------------------------------------------------------------------------
 /**
  * Set the default value of a resource to a numeric value.
  */
 //--------------------------------------------------------------------------------------------------
-FUNCTION SetNumericDefault
+void admin_SetNumericDefault
 (
-    string path[io.MAX_RESOURCE_PATH_LEN] IN, ///< Absolute path of the resource.
-    double value IN
+    const char* LE_NONNULL path,
+        ///< [IN] Absolute path of the resource.
+    double value
+        ///< [IN]
 );
-
 
 //--------------------------------------------------------------------------------------------------
 /**
  * Set the default value of a resource to a string value.
  */
 //--------------------------------------------------------------------------------------------------
-FUNCTION SetStringDefault
+void admin_SetStringDefault
 (
-    string path[io.MAX_RESOURCE_PATH_LEN] IN, ///< Absolute path of the resource.
-    string value[io.MAX_STRING_VALUE_LEN] IN
+    const char* LE_NONNULL path,
+        ///< [IN] Absolute path of the resource.
+    const char* LE_NONNULL value
+        ///< [IN]
 );
-
 
 //--------------------------------------------------------------------------------------------------
 /**
  * Set the default value of a resource to a JSON value.
  */
 //--------------------------------------------------------------------------------------------------
-FUNCTION SetJsonDefault
+void admin_SetJsonDefault
 (
-    string path[io.MAX_RESOURCE_PATH_LEN] IN, ///< Absolute path of the resource.
-    string value[io.MAX_STRING_VALUE_LEN] IN
+    const char* LE_NONNULL path,
+        ///< [IN] Absolute path of the resource.
+    const char* LE_NONNULL value
+        ///< [IN]
 );
-
 
 //--------------------------------------------------------------------------------------------------
 /**
@@ -1378,11 +1402,11 @@ FUNCTION SetJsonDefault
  * @return true if there is a default value set, false if not.
  */
 //--------------------------------------------------------------------------------------------------
-FUNCTION bool HasDefault
+bool admin_HasDefault
 (
-    string path[io.MAX_RESOURCE_PATH_LEN] IN  ///< Absolute path of the resource.
+    const char* LE_NONNULL path
+        ///< [IN] Absolute path of the resource.
 );
-
 
 //--------------------------------------------------------------------------------------------------
 /**
@@ -1391,11 +1415,11 @@ FUNCTION bool HasDefault
  * @return The data type, or IO_DATA_TYPE_TRIGGER if not set.
  */
 //--------------------------------------------------------------------------------------------------
-FUNCTION io.DataType GetDefaultDataType
+io_DataType_t admin_GetDefaultDataType
 (
-    string path[io.MAX_RESOURCE_PATH_LEN] IN  ///< Absolute path of the resource.
+    const char* LE_NONNULL path
+        ///< [IN] Absolute path of the resource.
 );
-
 
 //--------------------------------------------------------------------------------------------------
 /**
@@ -1404,11 +1428,11 @@ FUNCTION io.DataType GetDefaultDataType
  * @return the default value, or false if not set or set to another data type.
  */
 //--------------------------------------------------------------------------------------------------
-FUNCTION bool GetBooleanDefault
+bool admin_GetBooleanDefault
 (
-    string path[io.MAX_RESOURCE_PATH_LEN] IN  ///< Absolute path of the resource.
+    const char* LE_NONNULL path
+        ///< [IN] Absolute path of the resource.
 );
-
 
 //--------------------------------------------------------------------------------------------------
 /**
@@ -1417,11 +1441,11 @@ FUNCTION bool GetBooleanDefault
  * @return the default value, or NAN (not a number) if not set or set to another data type.
  */
 //--------------------------------------------------------------------------------------------------
-FUNCTION double GetNumericDefault
+double admin_GetNumericDefault
 (
-    string path[io.MAX_RESOURCE_PATH_LEN] IN  ///< Absolute path of the resource.
+    const char* LE_NONNULL path
+        ///< [IN] Absolute path of the resource.
 );
-
 
 //--------------------------------------------------------------------------------------------------
 /**
@@ -1433,12 +1457,15 @@ FUNCTION double GetNumericDefault
  *  - LE_NOT_FOUND if the resource doesn't have a string default value set.
  */
 //--------------------------------------------------------------------------------------------------
-FUNCTION le_result_t GetStringDefault
+le_result_t admin_GetStringDefault
 (
-    string path[io.MAX_RESOURCE_PATH_LEN] IN, ///< Absolute path of the resource.
-    string value[io.MAX_STRING_VALUE_LEN] OUT
+    const char* LE_NONNULL path,
+        ///< [IN] Absolute path of the resource.
+    char* value,
+        ///< [OUT]
+    size_t valueSize
+        ///< [IN]
 );
-
 
 //--------------------------------------------------------------------------------------------------
 /**
@@ -1452,23 +1479,26 @@ FUNCTION le_result_t GetStringDefault
  *  - LE_NOT_FOUND if the resource doesn't have a default value set.
  */
 //--------------------------------------------------------------------------------------------------
-FUNCTION le_result_t GetJsonDefault
+le_result_t admin_GetJsonDefault
 (
-    string path[io.MAX_RESOURCE_PATH_LEN] IN, ///< Absolute path of the resource.
-    string value[io.MAX_STRING_VALUE_LEN] OUT
+    const char* LE_NONNULL path,
+        ///< [IN] Absolute path of the resource.
+    char* value,
+        ///< [OUT]
+    size_t valueSize
+        ///< [IN]
 );
-
 
 //--------------------------------------------------------------------------------------------------
 /**
  * Remove any default value on a given resource.
  */
 //--------------------------------------------------------------------------------------------------
-FUNCTION RemoveDefault
+void admin_RemoveDefault
 (
-    string path[io.MAX_RESOURCE_PATH_LEN] IN  ///< Absolute path of the resource.
+    const char* LE_NONNULL path
+        ///< [IN] Absolute path of the resource.
 );
-
 
 //--------------------------------------------------------------------------------------------------
 /**
@@ -1478,12 +1508,13 @@ FUNCTION RemoveDefault
  *       does not match the data type of the Input or Output.
  */
 //--------------------------------------------------------------------------------------------------
-FUNCTION SetBooleanOverride
+void admin_SetBooleanOverride
 (
-    string path[io.MAX_RESOURCE_PATH_LEN] IN, ///< Absolute path of the resource.
-    bool value IN
+    const char* LE_NONNULL path,
+        ///< [IN] Absolute path of the resource.
+    bool value
+        ///< [IN]
 );
-
 
 //--------------------------------------------------------------------------------------------------
 /**
@@ -1493,12 +1524,13 @@ FUNCTION SetBooleanOverride
  *       does not match the data type of the Input or Output.
  */
 //--------------------------------------------------------------------------------------------------
-FUNCTION SetNumericOverride
+void admin_SetNumericOverride
 (
-    string path[io.MAX_RESOURCE_PATH_LEN] IN, ///< Absolute path of the resource.
-    double value IN
+    const char* LE_NONNULL path,
+        ///< [IN] Absolute path of the resource.
+    double value
+        ///< [IN]
 );
-
 
 //--------------------------------------------------------------------------------------------------
 /**
@@ -1508,12 +1540,13 @@ FUNCTION SetNumericOverride
  *       does not match the data type of the Input or Output.
  */
 //--------------------------------------------------------------------------------------------------
-FUNCTION SetStringOverride
+void admin_SetStringOverride
 (
-    string path[io.MAX_RESOURCE_PATH_LEN] IN, ///< Absolute path of the resource.
-    string value[io.MAX_STRING_VALUE_LEN] IN
+    const char* LE_NONNULL path,
+        ///< [IN] Absolute path of the resource.
+    const char* LE_NONNULL value
+        ///< [IN]
 );
-
 
 //--------------------------------------------------------------------------------------------------
 /**
@@ -1523,12 +1556,13 @@ FUNCTION SetStringOverride
  *       does not match the data type of the Input or Output.
  */
 //--------------------------------------------------------------------------------------------------
-FUNCTION SetJsonOverride
+void admin_SetJsonOverride
 (
-    string path[io.MAX_RESOURCE_PATH_LEN] IN, ///< Absolute path of the resource.
-    string value[io.MAX_STRING_VALUE_LEN] IN
+    const char* LE_NONNULL path,
+        ///< [IN] Absolute path of the resource.
+    const char* LE_NONNULL value
+        ///< [IN]
 );
-
 
 //--------------------------------------------------------------------------------------------------
 /**
@@ -1543,11 +1577,11 @@ FUNCTION SetJsonOverride
  *       definitely be overridden.
  */
 //--------------------------------------------------------------------------------------------------
-FUNCTION bool HasOverride
+bool admin_HasOverride
 (
-    string path[io.MAX_RESOURCE_PATH_LEN] IN  ///< Absolute path of the resource.
+    const char* LE_NONNULL path
+        ///< [IN] Absolute path of the resource.
 );
-
 
 //--------------------------------------------------------------------------------------------------
 /**
@@ -1556,11 +1590,11 @@ FUNCTION bool HasOverride
  * @return The data type, or IO_DATA_TYPE_TRIGGER if not set.
  */
 //--------------------------------------------------------------------------------------------------
-FUNCTION io.DataType GetOverrideDataType
+io_DataType_t admin_GetOverrideDataType
 (
-    string path[io.MAX_RESOURCE_PATH_LEN] IN  ///< Absolute path of the resource.
+    const char* LE_NONNULL path
+        ///< [IN] Absolute path of the resource.
 );
-
 
 //--------------------------------------------------------------------------------------------------
 /**
@@ -1569,11 +1603,11 @@ FUNCTION io.DataType GetOverrideDataType
  * @return the override value, or false if not set or set to another data type.
  */
 //--------------------------------------------------------------------------------------------------
-FUNCTION bool GetBooleanOverride
+bool admin_GetBooleanOverride
 (
-    string path[io.MAX_RESOURCE_PATH_LEN] IN  ///< Absolute path of the resource.
+    const char* LE_NONNULL path
+        ///< [IN] Absolute path of the resource.
 );
-
 
 //--------------------------------------------------------------------------------------------------
 /**
@@ -1582,11 +1616,11 @@ FUNCTION bool GetBooleanOverride
  * @return the override value, or NAN (not a number) if not set or set to another data type.
  */
 //--------------------------------------------------------------------------------------------------
-FUNCTION double GetNumericOverride
+double admin_GetNumericOverride
 (
-    string path[io.MAX_RESOURCE_PATH_LEN] IN  ///< Absolute path of the resource.
+    const char* LE_NONNULL path
+        ///< [IN] Absolute path of the resource.
 );
-
 
 //--------------------------------------------------------------------------------------------------
 /**
@@ -1598,12 +1632,15 @@ FUNCTION double GetNumericOverride
  *  - LE_NOT_FOUND if the resource doesn't have a string override value set.
  */
 //--------------------------------------------------------------------------------------------------
-FUNCTION le_result_t GetStringOverride
+le_result_t admin_GetStringOverride
 (
-    string path[io.MAX_RESOURCE_PATH_LEN] IN, ///< Absolute path of the resource.
-    string value[io.MAX_STRING_VALUE_LEN] OUT
+    const char* LE_NONNULL path,
+        ///< [IN] Absolute path of the resource.
+    char* value,
+        ///< [OUT]
+    size_t valueSize
+        ///< [IN]
 );
-
 
 //--------------------------------------------------------------------------------------------------
 /**
@@ -1617,23 +1654,26 @@ FUNCTION le_result_t GetStringOverride
  *  - LE_NOT_FOUND if the resource doesn't have an override value set.
  */
 //--------------------------------------------------------------------------------------------------
-FUNCTION le_result_t GetJsonOverride
+le_result_t admin_GetJsonOverride
 (
-    string path[io.MAX_RESOURCE_PATH_LEN] IN, ///< Absolute path of the resource.
-    string value[io.MAX_STRING_VALUE_LEN] OUT
+    const char* LE_NONNULL path,
+        ///< [IN] Absolute path of the resource.
+    char* value,
+        ///< [OUT]
+    size_t valueSize
+        ///< [IN]
 );
-
 
 //--------------------------------------------------------------------------------------------------
 /**
  * Remove any override on a given resource.
  */
 //--------------------------------------------------------------------------------------------------
-FUNCTION RemoveOverride
+void admin_RemoveOverride
 (
-    string path[io.MAX_RESOURCE_PATH_LEN] IN  ///< Absolute path of the resource.
+    const char* LE_NONNULL path
+        ///< [IN] Absolute path of the resource.
 );
-
 
 //--------------------------------------------------------------------------------------------------
 /**
@@ -1645,12 +1685,15 @@ FUNCTION RemoveOverride
  *  - LE_NOT_FOUND if the resource doesn't have any children.
  */
 //--------------------------------------------------------------------------------------------------
-FUNCTION le_result_t GetFirstChild
+le_result_t admin_GetFirstChild
 (
-    string path[io.MAX_RESOURCE_PATH_LEN] IN, ///< Absolute path of the resource.
-    string child[io.MAX_RESOURCE_PATH_LEN] OUT  ///< Absolute path of the first child resource.
+    const char* LE_NONNULL path,
+        ///< [IN] Absolute path of the resource.
+    char* child,
+        ///< [OUT] Absolute path of the first child resource.
+    size_t childSize
+        ///< [IN]
 );
-
 
 //--------------------------------------------------------------------------------------------------
 /**
@@ -1662,12 +1705,15 @@ FUNCTION le_result_t GetFirstChild
  *  - LE_NOT_FOUND if the resource is the last child in its parent's list of children.
  */
 //--------------------------------------------------------------------------------------------------
-FUNCTION le_result_t GetNextSibling
+le_result_t admin_GetNextSibling
 (
-    string path[io.MAX_RESOURCE_PATH_LEN] IN, ///< Absolute path of the resource.
-    string sibling[io.MAX_RESOURCE_PATH_LEN] OUT  ///< Absolute path of the next sibling resource.
+    const char* LE_NONNULL path,
+        ///< [IN] Absolute path of the resource.
+    char* sibling,
+        ///< [OUT] Absolute path of the next sibling resource.
+    size_t siblingSize
+        ///< [IN]
 );
-
 
 //--------------------------------------------------------------------------------------------------
 /**
@@ -1676,11 +1722,11 @@ FUNCTION le_result_t GetNextSibling
  * @return The entry type. ADMIN_ENTRY_TYPE_NONE if there's no entry at the given path.
  */
 //--------------------------------------------------------------------------------------------------
-FUNCTION EntryType GetEntryType
+admin_EntryType_t admin_GetEntryType
 (
-    string path[io.MAX_RESOURCE_PATH_LEN] IN ///< Absolute path of the resource.
+    const char* LE_NONNULL path
+        ///< [IN] Absolute path of the resource.
 );
-
 
 //--------------------------------------------------------------------------------------------------
 /**
@@ -1690,36 +1736,35 @@ FUNCTION EntryType GetEntryType
  * @return true if a mandatory output, false if it's an optional output or not an output at all.
  */
 //--------------------------------------------------------------------------------------------------
-FUNCTION bool IsMandatory
+bool admin_IsMandatory
 (
-    string path[io.MAX_RESOURCE_PATH_LEN] IN ///< Absolute path of the resource.
+    const char* LE_NONNULL path
+        ///< [IN] Absolute path of the resource.
 );
-
 
 //--------------------------------------------------------------------------------------------------
 /**
- * Register a handler, to be called back whenever a Resource is added or removed
+ * Add handler function for EVENT 'admin_ResourceTreeChange'
  */
 //--------------------------------------------------------------------------------------------------
-HANDLER ResourceTreeChangeHandler
+admin_ResourceTreeChangeHandlerRef_t admin_AddResourceTreeChangeHandler
 (
-    string path[io.MAX_RESOURCE_PATH_LEN] IN, ///< Absolute path of the resource.
-    EntryType entryType IN, ///< The type of the Resource (Input / Output / ...)
-    ResourceOperationType operation IN ///< Whether the Resource was added or Removed
+    admin_ResourceTreeChangeHandlerFunc_t callbackPtr,
+        ///< [IN]
+    void* contextPtr
+        ///< [IN]
 );
 
-
 //--------------------------------------------------------------------------------------------------
-/*
- * Causes the AddResourceChangeHandler() and RemoveResourceChangeHandler() functions
- * to be generated by the Legato build tools.
+/**
+ * Remove handler function for EVENT 'admin_ResourceTreeChange'
  */
 //--------------------------------------------------------------------------------------------------
-EVENT ResourceTreeChange
+void admin_RemoveResourceTreeChangeHandler
 (
-    ResourceTreeChangeHandler callback
+    admin_ResourceTreeChangeHandlerRef_t handlerRef
+        ///< [IN]
 );
-
 
 //--------------------------------------------------------------------------------------------------
 /**
@@ -1728,10 +1773,10 @@ EVENT ResourceTreeChange
  * This will result in call-backs to any handlers registered using io_AddUpdateStartEndHandler().
  */
 //--------------------------------------------------------------------------------------------------
-FUNCTION StartUpdate
+void admin_StartUpdate
 (
+    void
 );
-
 
 //--------------------------------------------------------------------------------------------------
 /**
@@ -1745,6 +1790,9 @@ FUNCTION StartUpdate
  * io_AddUpdateStartEndHandler().
  */
 //--------------------------------------------------------------------------------------------------
-FUNCTION EndUpdate
+void admin_EndUpdate
 (
+    void
 );
+
+#endif // ADMIN_INTERFACE_H_INCLUDE_GUARD

--- a/test/admin/interfaces.h
+++ b/test/admin/interfaces.h
@@ -1,0 +1,30 @@
+#ifndef __INTERFACE_H__
+#define __INTERFACE_H__
+
+#include "io_interface.h"
+#include "admin_interface.h"
+#include "query_interface.h"
+
+//--------------------------------------------------------------------------------------------------
+/**
+ * Maximum length of application names.
+ */
+//--------------------------------------------------------------------------------------------------
+#define LE_LIMIT_APP_NAME_LEN 47
+
+//--------------------------------------------------------------------------------------------------
+/**
+ * Get the client session reference for the current message
+ */
+//--------------------------------------------------------------------------------------------------
+le_msg_SessionRef_t io_GetClientSessionRef(void);
+le_msg_SessionRef_t query_GetClientSessionRef(void);
+
+le_result_t le_appInfo_GetName
+(
+    int32_t  pid,           ///< [IN]  PID of the process.
+    char    *appNameStr,    ///< [OUT] Application name buffer.
+    size_t   appNameSize    ///< [IN]  Buffer size.
+);
+
+#endif

--- a/test/admin/io_common.h
+++ b/test/admin/io_common.h
@@ -1,0 +1,754 @@
+
+/*
+ * ====================== WARNING ======================
+ *
+ * THE CONTENTS OF THIS FILE HAVE BEEN AUTO-GENERATED.
+ * DO NOT MODIFY IN ANY WAY.
+ *
+ * ====================== WARNING ======================
+ */
+#ifndef IO_COMMON_H_INCLUDE_GUARD
+#define IO_COMMON_H_INCLUDE_GUARD
+
+
+#include "legato.h"
+
+#define IFGEN_IO_PROTOCOL_ID "a2dafb94eca240de32c6cbd223a593ba"
+#define IFGEN_IO_MSG_SIZE 50103
+
+
+
+//--------------------------------------------------------------------------------------------------
+/**
+ * Constant used in place of a timestamp, when pushing samples to the Data Hub, to ask the Data Hub
+ * to generate a timestamp for the sample.
+ */
+//--------------------------------------------------------------------------------------------------
+#define IO_NOW 0
+
+//--------------------------------------------------------------------------------------------------
+/**
+ * Maximum number of bytes (excluding null terminator) in an I/O resource's path within its
+ * namespace in the Data Hub's resource tree.
+ */
+//--------------------------------------------------------------------------------------------------
+#ifndef IO_MAX_RESOURCE_PATH_LEN
+#define IO_MAX_RESOURCE_PATH_LEN 79
+#endif
+
+//--------------------------------------------------------------------------------------------------
+/**
+ * Maximum number of bytes (excluding terminator) in the value of a string type data sample.
+ */
+//--------------------------------------------------------------------------------------------------
+#ifndef IO_MAX_STRING_VALUE_LEN
+#define IO_MAX_STRING_VALUE_LEN 50000
+#endif
+
+//--------------------------------------------------------------------------------------------------
+/**
+ * Maximum number of bytes (excluding terminator) in the units string of a numeric I/O resource.
+ */
+//--------------------------------------------------------------------------------------------------
+#define IO_MAX_UNITS_NAME_LEN 23
+
+//--------------------------------------------------------------------------------------------------
+/**
+ * Enumerates the data types supported.
+ */
+//--------------------------------------------------------------------------------------------------
+typedef enum
+{
+    IO_DATA_TYPE_TRIGGER = 0,
+        ///< trigger
+    IO_DATA_TYPE_BOOLEAN = 1,
+        ///< Boolean
+    IO_DATA_TYPE_NUMERIC = 2,
+        ///< numeric (floating point number)
+    IO_DATA_TYPE_STRING = 3,
+        ///< string
+    IO_DATA_TYPE_JSON = 4
+        ///< JSON
+}
+io_DataType_t;
+
+
+//--------------------------------------------------------------------------------------------------
+/**
+ * Reference type used by Add/Remove functions for EVENT 'io_TriggerPush'
+ */
+//--------------------------------------------------------------------------------------------------
+typedef struct io_TriggerPushHandler* io_TriggerPushHandlerRef_t;
+
+
+//--------------------------------------------------------------------------------------------------
+/**
+ * Reference type used by Add/Remove functions for EVENT 'io_BooleanPush'
+ */
+//--------------------------------------------------------------------------------------------------
+typedef struct io_BooleanPushHandler* io_BooleanPushHandlerRef_t;
+
+
+//--------------------------------------------------------------------------------------------------
+/**
+ * Reference type used by Add/Remove functions for EVENT 'io_NumericPush'
+ */
+//--------------------------------------------------------------------------------------------------
+typedef struct io_NumericPushHandler* io_NumericPushHandlerRef_t;
+
+
+//--------------------------------------------------------------------------------------------------
+/**
+ * Reference type used by Add/Remove functions for EVENT 'io_StringPush'
+ */
+//--------------------------------------------------------------------------------------------------
+typedef struct io_StringPushHandler* io_StringPushHandlerRef_t;
+
+
+//--------------------------------------------------------------------------------------------------
+/**
+ * Reference type used by Add/Remove functions for EVENT 'io_JsonPush'
+ */
+//--------------------------------------------------------------------------------------------------
+typedef struct io_JsonPushHandler* io_JsonPushHandlerRef_t;
+
+
+//--------------------------------------------------------------------------------------------------
+/**
+ * Reference type used by Add/Remove functions for EVENT 'io_UpdateStartEnd'
+ */
+//--------------------------------------------------------------------------------------------------
+typedef struct io_UpdateStartEndHandler* io_UpdateStartEndHandlerRef_t;
+
+
+//--------------------------------------------------------------------------------------------------
+/**
+ * Callback function for pushing triggers to an output
+ */
+//--------------------------------------------------------------------------------------------------
+typedef void (*io_TriggerPushHandlerFunc_t)
+(
+        double timestamp,
+        ///< Timestamp in seconds since the Epoch 1970-01-01 00:00:00 +0000 (UTC).
+        void* contextPtr
+        ///<
+);
+
+//--------------------------------------------------------------------------------------------------
+/**
+ * Callback function for pushing Boolean values to an output
+ */
+//--------------------------------------------------------------------------------------------------
+typedef void (*io_BooleanPushHandlerFunc_t)
+(
+        double timestamp,
+        ///< Timestamp in seconds since the Epoch 1970-01-01 00:00:00 +0000 (UTC).
+        bool value,
+        ///<
+        void* contextPtr
+        ///<
+);
+
+//--------------------------------------------------------------------------------------------------
+/**
+ * Callback function for pushing numeric values to an output
+ */
+//--------------------------------------------------------------------------------------------------
+typedef void (*io_NumericPushHandlerFunc_t)
+(
+        double timestamp,
+        ///< Timestamp in seconds since the Epoch 1970-01-01 00:00:00 +0000 (UTC).
+        double value,
+        ///<
+        void* contextPtr
+        ///<
+);
+
+//--------------------------------------------------------------------------------------------------
+/**
+ * Callback function for pushing string values to an output
+ */
+//--------------------------------------------------------------------------------------------------
+typedef void (*io_StringPushHandlerFunc_t)
+(
+        double timestamp,
+        ///< Timestamp in seconds since the Epoch 1970-01-01 00:00:00 +0000 (UTC).
+        const char* LE_NONNULL value,
+        ///<
+        void* contextPtr
+        ///<
+);
+
+//--------------------------------------------------------------------------------------------------
+/**
+ * Callback function for pushing JSON values to an output
+ */
+//--------------------------------------------------------------------------------------------------
+typedef void (*io_JsonPushHandlerFunc_t)
+(
+        double timestamp,
+        ///< Timestamp in seconds since the Epoch 1970-01-01 00:00:00 +0000 (UTC).
+        const char* LE_NONNULL value,
+        ///<
+        void* contextPtr
+        ///<
+);
+
+//--------------------------------------------------------------------------------------------------
+/**
+ * Callback function for notification that a Data Hub reconfiguration is beginning or ending.
+ */
+//--------------------------------------------------------------------------------------------------
+typedef void (*io_UpdateStartEndHandlerFunc_t)
+(
+        bool isStarting,
+        ///< true = an update is starting, false = the update has ended.
+        void* contextPtr
+        ///<
+);
+
+
+//--------------------------------------------------------------------------------------------------
+/**
+ * Get if this client bound locally.
+ */
+//--------------------------------------------------------------------------------------------------
+LE_SHARED bool ifgen_io_HasLocalBinding
+(
+    void
+);
+
+
+//--------------------------------------------------------------------------------------------------
+/**
+ * Init data that is common across all threads
+ */
+//--------------------------------------------------------------------------------------------------
+LE_SHARED void ifgen_io_InitCommonData
+(
+    void
+);
+
+
+//--------------------------------------------------------------------------------------------------
+/**
+ * Perform common initialization and open a session
+ */
+//--------------------------------------------------------------------------------------------------
+LE_SHARED le_result_t ifgen_io_OpenSession
+(
+    le_msg_SessionRef_t _ifgen_sessionRef,
+    bool isBlocking
+);
+
+//--------------------------------------------------------------------------------------------------
+/**
+ * Create an input resource, which is used to push data into the Data Hub.
+ *
+ * Does nothing if the resource already exists.
+ *
+ * @return
+ *  - LE_OK if successful.
+ *  - LE_DUPLICATE if a resource by that name exists but with different direction, type or units.
+ *  - LE_NO_MEMORY if the client is not permitted to create that many resources.
+ */
+//--------------------------------------------------------------------------------------------------
+LE_SHARED le_result_t ifgen_io_CreateInput
+(
+    le_msg_SessionRef_t _ifgen_sessionRef,
+        const char* LE_NONNULL path,
+        ///< [IN] Path within the client app's resource namespace.
+        io_DataType_t dataType,
+        ///< [IN] The data type.
+        const char* LE_NONNULL units
+        ///< [IN] e.g., "degC" (see senml); "" = unspecified.
+);
+
+//--------------------------------------------------------------------------------------------------
+/**
+ * Set the example value for a JSON-type Input resource.
+ *
+ * Does nothing if the resource is not found, is not an input, or doesn't have a JSON type.
+ */
+//--------------------------------------------------------------------------------------------------
+LE_SHARED void ifgen_io_SetJsonExample
+(
+    le_msg_SessionRef_t _ifgen_sessionRef,
+        const char* LE_NONNULL path,
+        ///< [IN] Path within the client app's resource namespace.
+        const char* LE_NONNULL example
+        ///< [IN] The example JSON value string.
+);
+
+//--------------------------------------------------------------------------------------------------
+/**
+ * Create an output resource, which is used to receive data output from the Data Hub.
+ *
+ * Does nothing if the resource already exists.
+ *
+ * @return
+ *  - LE_OK if successful.
+ *  - LE_DUPLICATE if a resource by that name exists but with different direction, type or units.
+ *  - LE_NO_MEMORY if the client is not permitted to create that many resources.
+ */
+//--------------------------------------------------------------------------------------------------
+LE_SHARED le_result_t ifgen_io_CreateOutput
+(
+    le_msg_SessionRef_t _ifgen_sessionRef,
+        const char* LE_NONNULL path,
+        ///< [IN] Path within the client app's resource namespace.
+        io_DataType_t dataType,
+        ///< [IN] The data type.
+        const char* LE_NONNULL units
+        ///< [IN] e.g., "degC" (see senml); "" = unspecified.
+);
+
+//--------------------------------------------------------------------------------------------------
+/**
+ * Delete a resource.
+ *
+ * Does nothing if the resource doesn't exist.
+ */
+//--------------------------------------------------------------------------------------------------
+LE_SHARED void ifgen_io_DeleteResource
+(
+    le_msg_SessionRef_t _ifgen_sessionRef,
+        const char* LE_NONNULL path
+        ///< [IN] Resource path within the client app's namespace.
+);
+
+//--------------------------------------------------------------------------------------------------
+/**
+ * Push a trigger type data sample.
+ */
+//--------------------------------------------------------------------------------------------------
+LE_SHARED void ifgen_io_PushTrigger
+(
+    le_msg_SessionRef_t _ifgen_sessionRef,
+        const char* LE_NONNULL path,
+        ///< [IN] Resource path within the client app's namespace.
+        double timestamp
+        ///< [IN] Timestamp in seconds since the Epoch 1970-01-01 00:00:00 +0000 (UTC).
+        ///< IO_NOW = now (i.e., generate a timestamp for me).
+);
+
+//--------------------------------------------------------------------------------------------------
+/**
+ * Push a Boolean type data sample.
+ */
+//--------------------------------------------------------------------------------------------------
+LE_SHARED void ifgen_io_PushBoolean
+(
+    le_msg_SessionRef_t _ifgen_sessionRef,
+        const char* LE_NONNULL path,
+        ///< [IN] Resource path within the client app's namespace.
+        double timestamp,
+        ///< [IN] Timestamp in seconds since the Epoch 1970-01-01 00:00:00 +0000 (UTC).
+        ///< IO_NOW = now (i.e., generate a timestamp for me).
+        bool value
+        ///< [IN]
+);
+
+//--------------------------------------------------------------------------------------------------
+/**
+ * Push a numeric type data sample.
+ */
+//--------------------------------------------------------------------------------------------------
+LE_SHARED void ifgen_io_PushNumeric
+(
+    le_msg_SessionRef_t _ifgen_sessionRef,
+        const char* LE_NONNULL path,
+        ///< [IN] Resource path within the client app's namespace.
+        double timestamp,
+        ///< [IN] Timestamp in seconds since the Epoch 1970-01-01 00:00:00 +0000 (UTC).
+        ///< IO_NOW = now (i.e., generate a timestamp for me).
+        double value
+        ///< [IN]
+);
+
+//--------------------------------------------------------------------------------------------------
+/**
+ * Push a string type data sample.
+ */
+//--------------------------------------------------------------------------------------------------
+LE_SHARED void ifgen_io_PushString
+(
+    le_msg_SessionRef_t _ifgen_sessionRef,
+        const char* LE_NONNULL path,
+        ///< [IN] Resource path within the client app's namespace.
+        double timestamp,
+        ///< [IN] Timestamp in seconds since the Epoch 1970-01-01 00:00:00 +0000 (UTC).
+        ///< IO_NOW = now (i.e., generate a timestamp for me).
+        const char* LE_NONNULL value
+        ///< [IN]
+);
+
+//--------------------------------------------------------------------------------------------------
+/**
+ * Push a JSON data sample.
+ */
+//--------------------------------------------------------------------------------------------------
+LE_SHARED void ifgen_io_PushJson
+(
+    le_msg_SessionRef_t _ifgen_sessionRef,
+        const char* LE_NONNULL path,
+        ///< [IN] Resource path within the client app's namespace.
+        double timestamp,
+        ///< [IN] Timestamp in seconds since the Epoch 1970-01-01 00:00:00 +0000 (UTC).
+        ///< IO_NOW = now (i.e., generate a timestamp for me).
+        const char* LE_NONNULL value
+        ///< [IN]
+);
+
+//--------------------------------------------------------------------------------------------------
+/**
+ * Add handler function for EVENT 'io_TriggerPush'
+ */
+//--------------------------------------------------------------------------------------------------
+LE_SHARED io_TriggerPushHandlerRef_t ifgen_io_AddTriggerPushHandler
+(
+    le_msg_SessionRef_t _ifgen_sessionRef,
+        const char* LE_NONNULL path,
+        ///< [IN] Resource path within the client app's namespace.
+        io_TriggerPushHandlerFunc_t callbackPtr,
+        ///< [IN]
+        void* contextPtr
+        ///< [IN]
+);
+
+//--------------------------------------------------------------------------------------------------
+/**
+ * Remove handler function for EVENT 'io_TriggerPush'
+ */
+//--------------------------------------------------------------------------------------------------
+LE_SHARED void ifgen_io_RemoveTriggerPushHandler
+(
+    le_msg_SessionRef_t _ifgen_sessionRef,
+        io_TriggerPushHandlerRef_t handlerRef
+        ///< [IN]
+);
+
+//--------------------------------------------------------------------------------------------------
+/**
+ * Add handler function for EVENT 'io_BooleanPush'
+ */
+//--------------------------------------------------------------------------------------------------
+LE_SHARED io_BooleanPushHandlerRef_t ifgen_io_AddBooleanPushHandler
+(
+    le_msg_SessionRef_t _ifgen_sessionRef,
+        const char* LE_NONNULL path,
+        ///< [IN] Resource path within the client app's namespace.
+        io_BooleanPushHandlerFunc_t callbackPtr,
+        ///< [IN]
+        void* contextPtr
+        ///< [IN]
+);
+
+//--------------------------------------------------------------------------------------------------
+/**
+ * Remove handler function for EVENT 'io_BooleanPush'
+ */
+//--------------------------------------------------------------------------------------------------
+LE_SHARED void ifgen_io_RemoveBooleanPushHandler
+(
+    le_msg_SessionRef_t _ifgen_sessionRef,
+        io_BooleanPushHandlerRef_t handlerRef
+        ///< [IN]
+);
+
+//--------------------------------------------------------------------------------------------------
+/**
+ * Add handler function for EVENT 'io_NumericPush'
+ */
+//--------------------------------------------------------------------------------------------------
+LE_SHARED io_NumericPushHandlerRef_t ifgen_io_AddNumericPushHandler
+(
+    le_msg_SessionRef_t _ifgen_sessionRef,
+        const char* LE_NONNULL path,
+        ///< [IN] Resource path within the client app's namespace.
+        io_NumericPushHandlerFunc_t callbackPtr,
+        ///< [IN]
+        void* contextPtr
+        ///< [IN]
+);
+
+//--------------------------------------------------------------------------------------------------
+/**
+ * Remove handler function for EVENT 'io_NumericPush'
+ */
+//--------------------------------------------------------------------------------------------------
+LE_SHARED void ifgen_io_RemoveNumericPushHandler
+(
+    le_msg_SessionRef_t _ifgen_sessionRef,
+        io_NumericPushHandlerRef_t handlerRef
+        ///< [IN]
+);
+
+//--------------------------------------------------------------------------------------------------
+/**
+ * Add handler function for EVENT 'io_StringPush'
+ */
+//--------------------------------------------------------------------------------------------------
+LE_SHARED io_StringPushHandlerRef_t ifgen_io_AddStringPushHandler
+(
+    le_msg_SessionRef_t _ifgen_sessionRef,
+        const char* LE_NONNULL path,
+        ///< [IN] Resource path within the client app's namespace.
+        io_StringPushHandlerFunc_t callbackPtr,
+        ///< [IN]
+        void* contextPtr
+        ///< [IN]
+);
+
+//--------------------------------------------------------------------------------------------------
+/**
+ * Remove handler function for EVENT 'io_StringPush'
+ */
+//--------------------------------------------------------------------------------------------------
+LE_SHARED void ifgen_io_RemoveStringPushHandler
+(
+    le_msg_SessionRef_t _ifgen_sessionRef,
+        io_StringPushHandlerRef_t handlerRef
+        ///< [IN]
+);
+
+//--------------------------------------------------------------------------------------------------
+/**
+ * Add handler function for EVENT 'io_JsonPush'
+ */
+//--------------------------------------------------------------------------------------------------
+LE_SHARED io_JsonPushHandlerRef_t ifgen_io_AddJsonPushHandler
+(
+    le_msg_SessionRef_t _ifgen_sessionRef,
+        const char* LE_NONNULL path,
+        ///< [IN] Resource path within the client app's namespace.
+        io_JsonPushHandlerFunc_t callbackPtr,
+        ///< [IN]
+        void* contextPtr
+        ///< [IN]
+);
+
+//--------------------------------------------------------------------------------------------------
+/**
+ * Remove handler function for EVENT 'io_JsonPush'
+ */
+//--------------------------------------------------------------------------------------------------
+LE_SHARED void ifgen_io_RemoveJsonPushHandler
+(
+    le_msg_SessionRef_t _ifgen_sessionRef,
+        io_JsonPushHandlerRef_t handlerRef
+        ///< [IN]
+);
+
+//--------------------------------------------------------------------------------------------------
+/**
+ * Mark an Output resource "optional".  (By default, they are marked "mandatory".)
+ */
+//--------------------------------------------------------------------------------------------------
+LE_SHARED void ifgen_io_MarkOptional
+(
+    le_msg_SessionRef_t _ifgen_sessionRef,
+        const char* LE_NONNULL path
+        ///< [IN] Resource path within the client app's namespace.
+);
+
+//--------------------------------------------------------------------------------------------------
+/**
+ * Set a Boolean type value as the default value of a given resource.
+ *
+ * @note This will be ignored if the resource already has a default value.
+ */
+//--------------------------------------------------------------------------------------------------
+LE_SHARED void ifgen_io_SetBooleanDefault
+(
+    le_msg_SessionRef_t _ifgen_sessionRef,
+        const char* LE_NONNULL path,
+        ///< [IN] Resource path within the client app's namespace.
+        bool value
+        ///< [IN]
+);
+
+//--------------------------------------------------------------------------------------------------
+/**
+ * Set a numeric type value as the default value of a given resource.
+ *
+ * @note This will be ignored if the resource already has a default value.
+ */
+//--------------------------------------------------------------------------------------------------
+LE_SHARED void ifgen_io_SetNumericDefault
+(
+    le_msg_SessionRef_t _ifgen_sessionRef,
+        const char* LE_NONNULL path,
+        ///< [IN] Resource path within the client app's namespace.
+        double value
+        ///< [IN]
+);
+
+//--------------------------------------------------------------------------------------------------
+/**
+ * Set a string type value as the default value of a given resource.
+ *
+ * @note This will be ignored if the resource already has a default value.
+ */
+//--------------------------------------------------------------------------------------------------
+LE_SHARED void ifgen_io_SetStringDefault
+(
+    le_msg_SessionRef_t _ifgen_sessionRef,
+        const char* LE_NONNULL path,
+        ///< [IN] Resource path within the client app's namespace.
+        const char* LE_NONNULL value
+        ///< [IN]
+);
+
+//--------------------------------------------------------------------------------------------------
+/**
+ * Set a JSON type value as the default value of a given resource.
+ *
+ * @note This will be ignored if the resource already has a default value.
+ */
+//--------------------------------------------------------------------------------------------------
+LE_SHARED void ifgen_io_SetJsonDefault
+(
+    le_msg_SessionRef_t _ifgen_sessionRef,
+        const char* LE_NONNULL path,
+        ///< [IN] Resource path within the client app's namespace.
+        const char* LE_NONNULL value
+        ///< [IN]
+);
+
+//--------------------------------------------------------------------------------------------------
+/**
+ * Fetch the timestamp of the current value of an Input or Output resource with any data type.
+ *
+ * @return
+ *  - LE_OK if successful.
+ *  - LE_NOT_FOUND if the resource does not exist.
+ *  - LE_UNAVAILABLE if the resource does not currently have a value.
+ */
+//--------------------------------------------------------------------------------------------------
+LE_SHARED le_result_t ifgen_io_GetTimestamp
+(
+    le_msg_SessionRef_t _ifgen_sessionRef,
+        const char* LE_NONNULL path,
+        ///< [IN] Resource path within the client app's namespace.
+        double* timestampPtr
+        ///< [OUT] Timestamp in seconds since the Epoch 1970-01-01 00:00:00 +0000 (UTC).
+);
+
+//--------------------------------------------------------------------------------------------------
+/**
+ * Fetch the current value of a Boolean type Input or Output resource.
+ *
+ * @return
+ *  - LE_OK if successful.
+ *  - LE_NOT_FOUND if the resource does not exist.
+ *  - LE_UNAVAILABLE if the resource does not currently have a value.
+ */
+//--------------------------------------------------------------------------------------------------
+LE_SHARED le_result_t ifgen_io_GetBoolean
+(
+    le_msg_SessionRef_t _ifgen_sessionRef,
+        const char* LE_NONNULL path,
+        ///< [IN] Resource path within the client app's namespace.
+        double* timestampPtr,
+        ///< [OUT] Timestamp in seconds since the Epoch 1970-01-01 00:00:00 +0000 (UTC).
+        bool* valuePtr
+        ///< [OUT]
+);
+
+//--------------------------------------------------------------------------------------------------
+/**
+ * Fetch the current value of a numeric type Input or Output resource.
+ *
+ * @return
+ *  - LE_OK if successful.
+ *  - LE_NOT_FOUND if the resource does not exist.
+ *  - LE_UNAVAILABLE if the resource does not currently have a value.
+ */
+//--------------------------------------------------------------------------------------------------
+LE_SHARED le_result_t ifgen_io_GetNumeric
+(
+    le_msg_SessionRef_t _ifgen_sessionRef,
+        const char* LE_NONNULL path,
+        ///< [IN] Resource path within the client app's namespace.
+        double* timestampPtr,
+        ///< [OUT] Timestamp in seconds since the Epoch 1970-01-01 00:00:00 +0000 (UTC).
+        double* valuePtr
+        ///< [OUT]
+);
+
+//--------------------------------------------------------------------------------------------------
+/**
+ * Fetch the current value of a string type Input or Output resource.
+ *
+ * @return
+ *  - LE_OK if successful.
+ *  - LE_OVERFLOW if the value buffer was too small to hold the value.
+ *  - LE_NOT_FOUND if the resource does not exist.
+ *  - LE_UNAVAILABLE if the resource does not currently have a value.
+ */
+//--------------------------------------------------------------------------------------------------
+LE_SHARED le_result_t ifgen_io_GetString
+(
+    le_msg_SessionRef_t _ifgen_sessionRef,
+        const char* LE_NONNULL path,
+        ///< [IN] Resource path within the client app's namespace.
+        double* timestampPtr,
+        ///< [OUT] Timestamp in seconds since the Epoch 1970-01-01 00:00:00 +0000 (UTC).
+        char* value,
+        ///< [OUT]
+        size_t valueSize
+        ///< [IN]
+);
+
+//--------------------------------------------------------------------------------------------------
+/**
+ * Fetch the current value of an Input or Output resource (of any data type) in JSON format.
+ *
+ * @return
+ *  - LE_OK if successful.
+ *  - LE_OVERFLOW if the value buffer was too small to hold the value.
+ *  - LE_NOT_FOUND if the resource does not exist.
+ *  - LE_UNAVAILABLE if the resource does not currently have a value.
+ */
+//--------------------------------------------------------------------------------------------------
+LE_SHARED le_result_t ifgen_io_GetJson
+(
+    le_msg_SessionRef_t _ifgen_sessionRef,
+        const char* LE_NONNULL path,
+        ///< [IN] Resource path within the client app's namespace.
+        double* timestampPtr,
+        ///< [OUT] Timestamp in seconds since the Epoch 1970-01-01 00:00:00 +0000 (UTC).
+        char* value,
+        ///< [OUT]
+        size_t valueSize
+        ///< [IN]
+);
+
+//--------------------------------------------------------------------------------------------------
+/**
+ * Add handler function for EVENT 'io_UpdateStartEnd'
+ */
+//--------------------------------------------------------------------------------------------------
+LE_SHARED io_UpdateStartEndHandlerRef_t ifgen_io_AddUpdateStartEndHandler
+(
+    le_msg_SessionRef_t _ifgen_sessionRef,
+        io_UpdateStartEndHandlerFunc_t callbackPtr,
+        ///< [IN]
+        void* contextPtr
+        ///< [IN]
+);
+
+//--------------------------------------------------------------------------------------------------
+/**
+ * Remove handler function for EVENT 'io_UpdateStartEnd'
+ */
+//--------------------------------------------------------------------------------------------------
+LE_SHARED void ifgen_io_RemoveUpdateStartEndHandler
+(
+    le_msg_SessionRef_t _ifgen_sessionRef,
+        io_UpdateStartEndHandlerRef_t handlerRef
+        ///< [IN]
+);
+
+#endif // IO_COMMON_H_INCLUDE_GUARD

--- a/test/admin/io_interface.h
+++ b/test/admin/io_interface.h
@@ -1,0 +1,1005 @@
+
+
+/*
+ * ====================== WARNING ======================
+ *
+ * THE CONTENTS OF THIS FILE HAVE BEEN AUTO-GENERATED.
+ * DO NOT MODIFY IN ANY WAY.
+ *
+ * ====================== WARNING ======================
+ */
+
+/**
+ * @page c_dataHubIo Data Hub I/O API
+ *
+ * @ref io_interface.h "API Reference"
+ *
+ * This API allows applications to provide data input to the Data Hub and receive data output
+ * from the Data Hub.  This can be used to connect sensors and actuators to processing and
+ * connectivity apps.
+ *
+ *
+ * @section c_dataHubIo_Resources I/O Resources
+ *
+ * Clients create I/O "resources" within the Data Hub's resource tree.  Time-stamped
+ * data is "pushed" into the Data Hub via "Input" resources and can be received as output from
+ * the Data Hub via "Output" resources.
+ *
+ * Configuration of the routing, filtering, and buffering of this data inside the Data Hub is
+ * the responsibility of an "administrator" app, using the @ref c_dataHubAdmin.  Clients of the
+ * I/O API don't care about where the data is routed and how it is processed.  They just create
+ * their Input and Output resources and send and receive data through those.  This de-couples
+ * the I/O apps from the rest of the system, allowing them to be reused in different ways within
+ * different systems.
+ *
+ * Input resources (for pushing input to the Data Hub) are created using io_CreateInput().
+ *
+ * Output resources (for receiving output from the Data Hub) are created using io_CreateOutput().
+ *
+ * Both Input and Output resources can be deleted using io_DeleteResource().
+ *
+ * @note A resource that has been deleted by the I/O API client app may still appear in the
+ *       resource tree if the administrator has applied any settings to that resource. The
+ *       resource will only disappear from the resource tree when all administrative settings have
+ *       been removed *and* the app that created the resource has either deleted the resource or
+ *       disconnected from the Data Hub.
+ *
+ * Each I/O resource has the following attributes:
+ * - Path
+ * - Data type
+ * - Units
+ *
+ * @code
+ *
+ * le_result_t result = io_CreateInput("temperature/value", IO_DATA_TYPE_NUMERIC, "degC");
+ *
+ * @endcode
+ *
+ *
+ * @section c_dataHubIo_Paths Paths
+ *
+ * The path of a resource is its unique identifier within the Data Hub's resource tree.
+ *
+ * Each client of the I/O API is provided with its own namespace in the Data Hub's resource tree,
+ * so there's no need to worry about naming conflicts or access violations between client apps.
+ *
+ * For example, an app named "tempSensor" could create an input with the path "temperature/value".
+ * This would appear in the global resource tree at "/app/tempSensor/temperature/value".
+ * Meanwhile, another app named "heater" could create an output with the same app-local path
+ * ("temperature/value"), and it would appear under "/app/heater/temperature/value".
+ *
+ * An important set of conventions exist for structuring I/O resource paths:
+ * - A sensor's main input resource must be called "value".
+ * - An actuator's main output resource must be called "enable".
+ * - The name of the "value" or "enable" resource's parent is the name of the sensor or actuator.
+ * - All output resources under the same parent as a "value" or "enable" resource are for related
+ *   settings.
+ *
+ * Furthermore, some conventions exist for settings related to sensors:
+ * - If a sensor has a boolean output resource called "enable" next to (under the same parent as)
+ *   its "value" resource, that "enable" resource can be used by administrator apps to disable the
+ *   sensor (by setting that output to "false").
+ * - If a boolean output resource called "period" appears next to a "value" input resource
+ *   then it can be used to tell the sensor to perform periodic sampling.
+ * - If a trigger output resource called "trigger" appears next to a "value" input resource
+ *   then it can be used to tell the sensor to push a single sample to its "value" input.
+ *
+ * For example,
+ *
+ * @verbatim
+/app
+  |
+  +--/airSensor
+  |   |
+  |   +--/temperature
+  |   |   |
+  |   |   +--/value = the temperature sensor input
+  |   |   |
+  |   |   +--/period = an output used to configure the temperature sensor's sampling period
+  |   |   |
+  |   |   +--/trigger = an output used to immediately trigger a single temperature sensor sample
+  |   |   |
+  |   |   +--/enable = an output used to enable or disable the temperature sensor
+  |   |
+  |   +--/humidity
+  |       |
+  |       +--/value = the humidity sensor input
+  |       |
+  |       +--/period = an output used to configure the humidity sensor's sampling period
+  |       |
+  |       +--/enable = an output used to enable or disable the humidity sensor
+  |
+  +--/lowBattery
+  |   |
+  |   +--/value = the lowBattery sensor input
+  |   |
+  |   +--/level = output used to configure the level at which the low battery alarm will trigger
+  |
+  +--/hvac
+      |
+      +--/temperature = the HVAC system's temperature setpoint output
+      |
+      +--/enable = an output used to enable or disable the HVAC system
+      |
+      +--/fanOn = an output used to control the fan mode (auto or always on)
+      |
+      +--/coolOff = an output used to control the cooling mode (auto or disabled)
+      |
+      +--/heatOff = an output used to control the heating mode (auto or disabled)
+ @endverbatim
+ *
+ * @note The @c enable output can be used to coordinate atomic updates to multiple output
+ * resources for the same sensor or actuator.  For example, if an analog-to-digital converter (ADC)
+ * accepts settings @c adc/min and @c adc/max to configure the scaling of the ADC reading into
+ * physical units like "degC" or "%RH", the sensor may produce garbage readings between the time
+ * that @c adc/min and @c adc/max are updated.  The sensor can then also provide @c adc/enable,
+ * which the admin tool can use to disable the ADC while it is updating @c adc/min and @c adc/max.
+ *
+ * Paths are not permitted to contain '.', '[', or ']' characters, as those are reserved for
+ * specifying members of structured JSON data samples in the @ref c_dataHubAdmin "Admin" and
+ * @ref c_dataHubQuery "Query" APIs.
+ *
+ *
+ * @section c_dataHubIo_DataTypes Data Types
+ *
+ * Data types supported are:
+ * - trigger = used to indicate an event that doesn't have any associated value.
+ * - Boolean = a Boolean (true or false) value
+ * - numeric = a double-precision floating point value.
+ * - string = a UTF-8 string value
+ * - JSON = a string in JSON format
+ *
+ * JSON and string Inputs and Outputs can receive any type of data, but other types of
+ * Input or Output can only receive one type of data.  E.g., a Boolean sample cannot
+ * be pushed to a trigger or numeric resource, and a string cannot be pushed to a Boolean, trigger,
+ * or numeric resource.
+ *
+ * Furthermore, JSON and string type push hander call-back functions can be registered on other
+ * types of Outputs, and a type conversion will happen automatically when the data sample is
+ * delivered to its consumer.  For example, if io_AddJsonPushHandler() is used to register a JSON
+ * Push Handler call-back on a numeric Output, whenever a numeric data sample arrives at that
+ * Output, the JSON push handler will be called with a string parameter containing the JSON
+ * representation of that numeric sample's value.
+ *
+ * @subsection c_dataHubIo_DataTypes_JsonExamples JSON Examples
+ *
+ * When a JSON Input is created, io_SetJsonExample() can be called to provide an example of what a
+ * value should look like.  This can be retrieved by the administrative app via a call to
+ * admin_GetJsonExample(), and allows the administrator to see (via an HMI of some kind) what a
+ * value might look like before the sensor is enabled.  This assists in the configuration of
+ * @ref c_dataHubAdmin_JsonExtraction "JSON extraction" before going live with data collection.
+ *
+ * @code
+ *
+ * io_SetJsonExample("accel/value", "{\"x\": 0, \"y\": 0, \"z\": 0}");
+ *
+ * @endcode
+ *
+ *
+ * @section c_dataHubIo_Units Units
+ *
+ * Scalar data values have units, such as degrees Celcius, Pascals, Hertz, etc.  Defects can arise
+ * if the sender and receiver of a data sample disagree on their units.  For example,
+ * https://en.wikipedia.org/wiki/Mars_Climate_Orbiter.
+ *
+ * When a numeric type I/O resource is created, it can have a string describing its units.
+ * If two resources do not agree on their units, data samples will not be routed between them.
+ *
+ * See the senml RFC draft for a list of units strings in section 12.1 Units Registry at
+ * https://tools.ietf.org/html/draft-ietf-core-senml-12#page-26.
+ *
+ *
+ * @section c_dataHubIo_PushingInput Pushing Data Into the Data Hub
+ *
+ * Data can be pushed to Inputs by calling one of the Push functions:
+ * - io_PushTrigger()
+ * - io_PushBoolean()
+ * - io_PushNumeric()
+ * - io_PushString()
+ * - io_PushJson()
+ *
+ * @note All of these @c Push() functions accept @c IO_NOW as a timestamp, which tells the
+ *       Data Hub to generate the timestamp.
+ *
+ * For example,
+ *
+ * @code
+ *
+ * io_PushNumeric(INPUT_NAME, IO_NOW, inputValue);
+ *
+ * @endcode
+ *
+ *
+ * @section c_dataHubIo_ReceivingOutput Receiving Output From the Data Hub
+ *
+ * Data can be pushed to Outputs by the Data Hub, and clients of the I/O API can register to
+ * receive call-backs when this happens:
+ * - io_AddTriggerPushHandler() (optionally remove using io_RemoveTriggerPushHandler())
+ * - io_AddBooleanPushHandler() (optionally remove using io_RemoveBooleanPushHandler())
+ * - io_AddNumericPushHandler() (optionally remove using io_RemoveNumericPushHandler())
+ * - io_AddStringPushHandler() (optionally remove using io_RemoveStringPushHandler())
+ * - io_AddJsonPushHandler() (optionally remove using io_RemoveJsonPushHandler())
+ *
+ * For example,
+ *
+ * @code
+ *
+ * // This is my enable/disable control.
+ * result = io_CreateOutput(ENABLE_NAME, IO_DATA_TYPE_BOOLEAN, "");
+ * LE_ASSERT(result == LE_OK);
+ *
+ * // Register for notification of updates to my enable/disable control.
+ * // My function EnableUpdateHandler() will be called when updates arrive for my enable/disable
+ * // control.
+ * io_AddBooleanPushHandler(ENABLE_NAME, EnableUpdateHandler, NULL);
+ *
+ * @endcode
+ *
+ * When a push handler is registered on a resource that already has a value, the push handler
+ * will be called to deliver that current value.  If the resource doesn't have a current value yet,
+ * then the push handler will not be called until the resource receives its first value.
+ *
+ * @note Deleting an Output will automatically remove all Push handler call-backs that have been
+ *       registered with that Output.
+ *
+ * It's also possible to fetch the current value of either an Input or an Output using one of the
+ * following functions:
+ * - io_GetTimestamp() - Get the timestamp of the current value (works with any data type)
+ * - io_GetBoolean() - Get the timestamp and the value. Only works with Boolean I/O resources.
+ * - io_GetNumeric() - Get the timestamp and the value. Only works with numeric I/O resources.
+ * - io_GetString() - Get the timestamp and the value. Only works with string I/O resources.
+ * - io_GetJson() - Get the timestamp and value (works with any data type)
+ *
+ * @note It's possible for a resource to not have any value. This will be indicated by a return
+ *       code.
+ *
+ * @code
+ *
+ * double timestamp;
+ * bool value;
+ *
+ * le_result_t result = io_GetBoolean(ENABLE_NAME, &timestamp, &value);
+ *
+ * if (result == LE_OK)
+ * {
+ *     printf("I'm currently %s.\n", value ? "enabled" : "disabled");
+ * }
+ * else
+ * {
+ *     LE_CRIT("Failed to fetch value of " ENABLE_NAME " (%s).", LE_RESULT_TXT(result));
+ * }
+ *
+ * @endcode
+ *
+ * @note If you need to ensure that your resource always has a current value, you can set its
+ *       default value right after you create it.
+ *
+ *
+ * @subsection c_dataHubIo_Mandatory Mandatory Outputs
+ *
+ * It's possible for a connected app (e.g., sensor or actuator) to have configuration settings
+ * that are considered mandatory to the operation of that app.  For example, a sensor may not
+ * be able to function unless it has received calibration data settings, or even just a sampling
+ * period setting.
+ *
+ * By default, all Outputs are considered mandatory, but an Output can be marked "optional"
+ * by calling io_MarkOptional().
+ *
+ * @code
+ * io_MarkOptional("temperature/offset");
+ * @endcode
+ *
+ * Alternatively, you can set a default value for your mandatory output.
+ *
+ * Administrative apps can see which resources are mandatory and which are optional, so warnings
+ * or hints can be displayed to developers or maintainers if mandatory Outputs are not given values.
+ *
+ *
+ * @section c_dataHubIo_DefaultValues Setting Default Values
+ *
+ * It's possible to tell the Data Hub that your Input or Output has a default value.
+ * if the resource doesn't already have a default value, the following functions will set it:
+ * - io_SetBooleanDefault()
+ * - io_SetNumericDefault()
+ * - io_SetStringDefault()
+ * - io_SetJsonDefault()
+ *
+ * For example,
+ *
+ * @code
+ *
+ * // This is my enable/disable control.
+ * result = io_CreateOutput(ENABLE_NAME, IO_DATA_TYPE_BOOLEAN, "");
+ * LE_ASSERT(result == LE_OK);
+ *
+ * // The default is to be disabled.
+ * io_SetBooleanDefault(ENABLE_NAME, false);
+ *
+ * @endcode
+ *
+ * If the resource already has a default value, then calls to these functions will be quietly
+ * ignored.
+ *
+ *
+ * @section c_dataHubIo_ConfigUpdateNotification Getting Notified of Configuration Changes
+ *
+ * If your app needs to be notified when the Data Hub is about to be reconfigured and/or when
+ * it has finished being reconfigured, you can register for notification call-backs using
+ * io_AddUpdateStartEndHandler().
+ *
+ * You might need to do this if you have several configuration settings that can be provided to
+ * you by the Data Hub via Output resources, and you need to be certain that they are configured
+ * consistently with each other in order to produce correct results.  For example, a sensor might
+ * have an offset and a scaling factor that are each delivered to it as separate outputs from the
+ * Data Hub.  If sensor readings are taken between the time that the offset is updated and the
+ * time that the scaling factor is updated, the sensor will produce garbage readings.  Instead,
+ * the sensor can get notified that a configuration update is happening, and suspend sampling until
+ * the configuration update is finished.
+ *
+ *
+ * Copyright (C) Sierra Wireless Inc.
+ *
+ * @file io_interface.h
+ */
+
+#ifndef IO_INTERFACE_H_INCLUDE_GUARD
+#define IO_INTERFACE_H_INCLUDE_GUARD
+
+
+#include "legato.h"
+
+// Internal includes for this interface
+#include "io_common.h"
+//--------------------------------------------------------------------------------------------------
+/**
+ * Type for handler called when a server disconnects.
+ */
+//--------------------------------------------------------------------------------------------------
+typedef void (*io_DisconnectHandler_t)(void *);
+
+//--------------------------------------------------------------------------------------------------
+/**
+ *
+ * Connect the current client thread to the service providing this API. Block until the service is
+ * available.
+ *
+ * For each thread that wants to use this API, either ConnectService or TryConnectService must be
+ * called before any other functions in this API.  Normally, ConnectService is automatically called
+ * for the main thread, but not for any other thread. For details, see @ref apiFilesC_client.
+ *
+ * This function is created automatically.
+ */
+//--------------------------------------------------------------------------------------------------
+void io_ConnectService
+(
+    void
+);
+
+//--------------------------------------------------------------------------------------------------
+/**
+ *
+ * Try to connect the current client thread to the service providing this API. Return with an error
+ * if the service is not available.
+ *
+ * For each thread that wants to use this API, either ConnectService or TryConnectService must be
+ * called before any other functions in this API.  Normally, ConnectService is automatically called
+ * for the main thread, but not for any other thread. For details, see @ref apiFilesC_client.
+ *
+ * This function is created automatically.
+ *
+ * @return
+ *  - LE_OK if the client connected successfully to the service.
+ *  - LE_UNAVAILABLE if the server is not currently offering the service to which the client is
+ *    bound.
+ *  - LE_NOT_PERMITTED if the client interface is not bound to any service (doesn't have a binding).
+ *  - LE_COMM_ERROR if the Service Directory cannot be reached.
+ */
+//--------------------------------------------------------------------------------------------------
+le_result_t io_TryConnectService
+(
+    void
+);
+
+//--------------------------------------------------------------------------------------------------
+/**
+ * Set handler called when server disconnection is detected.
+ *
+ * When a server connection is lost, call this handler then exit with LE_FATAL.  If a program wants
+ * to continue without exiting, it should call longjmp() from inside the handler.
+ */
+//--------------------------------------------------------------------------------------------------
+LE_FULL_API void io_SetServerDisconnectHandler
+(
+    io_DisconnectHandler_t disconnectHandler,
+    void *contextPtr
+);
+
+//--------------------------------------------------------------------------------------------------
+/**
+ *
+ * Disconnect the current client thread from the service providing this API.
+ *
+ * Normally, this function doesn't need to be called. After this function is called, there's no
+ * longer a connection to the service, and the functions in this API can't be used. For details, see
+ * @ref apiFilesC_client.
+ *
+ * This function is created automatically.
+ */
+//--------------------------------------------------------------------------------------------------
+void io_DisconnectService
+(
+    void
+);
+
+
+//--------------------------------------------------------------------------------------------------
+/**
+ * Enumerates the data types supported.
+ */
+//--------------------------------------------------------------------------------------------------
+
+
+//--------------------------------------------------------------------------------------------------
+/**
+ * Callback function for pushing triggers to an output
+ */
+//--------------------------------------------------------------------------------------------------
+
+
+//--------------------------------------------------------------------------------------------------
+/**
+ * Reference type used by Add/Remove functions for EVENT 'io_TriggerPush'
+ */
+//--------------------------------------------------------------------------------------------------
+
+
+//--------------------------------------------------------------------------------------------------
+/**
+ * Callback function for pushing Boolean values to an output
+ */
+//--------------------------------------------------------------------------------------------------
+
+
+//--------------------------------------------------------------------------------------------------
+/**
+ * Reference type used by Add/Remove functions for EVENT 'io_BooleanPush'
+ */
+//--------------------------------------------------------------------------------------------------
+
+
+//--------------------------------------------------------------------------------------------------
+/**
+ * Callback function for pushing numeric values to an output
+ */
+//--------------------------------------------------------------------------------------------------
+
+
+//--------------------------------------------------------------------------------------------------
+/**
+ * Reference type used by Add/Remove functions for EVENT 'io_NumericPush'
+ */
+//--------------------------------------------------------------------------------------------------
+
+
+//--------------------------------------------------------------------------------------------------
+/**
+ * Callback function for pushing string values to an output
+ */
+//--------------------------------------------------------------------------------------------------
+
+
+//--------------------------------------------------------------------------------------------------
+/**
+ * Reference type used by Add/Remove functions for EVENT 'io_StringPush'
+ */
+//--------------------------------------------------------------------------------------------------
+
+
+//--------------------------------------------------------------------------------------------------
+/**
+ * Callback function for pushing JSON values to an output
+ */
+//--------------------------------------------------------------------------------------------------
+
+
+//--------------------------------------------------------------------------------------------------
+/**
+ * Reference type used by Add/Remove functions for EVENT 'io_JsonPush'
+ */
+//--------------------------------------------------------------------------------------------------
+
+
+//--------------------------------------------------------------------------------------------------
+/**
+ * Callback function for notification that a Data Hub reconfiguration is beginning or ending.
+ */
+//--------------------------------------------------------------------------------------------------
+
+
+//--------------------------------------------------------------------------------------------------
+/**
+ * Reference type used by Add/Remove functions for EVENT 'io_UpdateStartEnd'
+ */
+//--------------------------------------------------------------------------------------------------
+
+
+//--------------------------------------------------------------------------------------------------
+/**
+ * Create an input resource, which is used to push data into the Data Hub.
+ *
+ * Does nothing if the resource already exists.
+ *
+ * @return
+ *  - LE_OK if successful.
+ *  - LE_DUPLICATE if a resource by that name exists but with different direction, type or units.
+ *  - LE_NO_MEMORY if the client is not permitted to create that many resources.
+ */
+//--------------------------------------------------------------------------------------------------
+le_result_t io_CreateInput
+(
+    const char* LE_NONNULL path,
+        ///< [IN] Path within the client app's resource namespace.
+    io_DataType_t dataType,
+        ///< [IN] The data type.
+    const char* LE_NONNULL units
+        ///< [IN] e.g., "degC" (see senml); "" = unspecified.
+);
+
+//--------------------------------------------------------------------------------------------------
+/**
+ * Set the example value for a JSON-type Input resource.
+ *
+ * Does nothing if the resource is not found, is not an input, or doesn't have a JSON type.
+ */
+//--------------------------------------------------------------------------------------------------
+void io_SetJsonExample
+(
+    const char* LE_NONNULL path,
+        ///< [IN] Path within the client app's resource namespace.
+    const char* LE_NONNULL example
+        ///< [IN] The example JSON value string.
+);
+
+//--------------------------------------------------------------------------------------------------
+/**
+ * Create an output resource, which is used to receive data output from the Data Hub.
+ *
+ * Does nothing if the resource already exists.
+ *
+ * @return
+ *  - LE_OK if successful.
+ *  - LE_DUPLICATE if a resource by that name exists but with different direction, type or units.
+ *  - LE_NO_MEMORY if the client is not permitted to create that many resources.
+ */
+//--------------------------------------------------------------------------------------------------
+le_result_t io_CreateOutput
+(
+    const char* LE_NONNULL path,
+        ///< [IN] Path within the client app's resource namespace.
+    io_DataType_t dataType,
+        ///< [IN] The data type.
+    const char* LE_NONNULL units
+        ///< [IN] e.g., "degC" (see senml); "" = unspecified.
+);
+
+//--------------------------------------------------------------------------------------------------
+/**
+ * Delete a resource.
+ *
+ * Does nothing if the resource doesn't exist.
+ */
+//--------------------------------------------------------------------------------------------------
+void io_DeleteResource
+(
+    const char* LE_NONNULL path
+        ///< [IN] Resource path within the client app's namespace.
+);
+
+//--------------------------------------------------------------------------------------------------
+/**
+ * Push a trigger type data sample.
+ */
+//--------------------------------------------------------------------------------------------------
+void io_PushTrigger
+(
+    const char* LE_NONNULL path,
+        ///< [IN] Resource path within the client app's namespace.
+    double timestamp
+        ///< [IN] Timestamp in seconds since the Epoch 1970-01-01 00:00:00 +0000 (UTC).
+        ///< IO_NOW = now (i.e., generate a timestamp for me).
+);
+
+//--------------------------------------------------------------------------------------------------
+/**
+ * Push a Boolean type data sample.
+ */
+//--------------------------------------------------------------------------------------------------
+void io_PushBoolean
+(
+    const char* LE_NONNULL path,
+        ///< [IN] Resource path within the client app's namespace.
+    double timestamp,
+        ///< [IN] Timestamp in seconds since the Epoch 1970-01-01 00:00:00 +0000 (UTC).
+        ///< IO_NOW = now (i.e., generate a timestamp for me).
+    bool value
+        ///< [IN]
+);
+
+//--------------------------------------------------------------------------------------------------
+/**
+ * Push a numeric type data sample.
+ */
+//--------------------------------------------------------------------------------------------------
+void io_PushNumeric
+(
+    const char* LE_NONNULL path,
+        ///< [IN] Resource path within the client app's namespace.
+    double timestamp,
+        ///< [IN] Timestamp in seconds since the Epoch 1970-01-01 00:00:00 +0000 (UTC).
+        ///< IO_NOW = now (i.e., generate a timestamp for me).
+    double value
+        ///< [IN]
+);
+
+//--------------------------------------------------------------------------------------------------
+/**
+ * Push a string type data sample.
+ */
+//--------------------------------------------------------------------------------------------------
+void io_PushString
+(
+    const char* LE_NONNULL path,
+        ///< [IN] Resource path within the client app's namespace.
+    double timestamp,
+        ///< [IN] Timestamp in seconds since the Epoch 1970-01-01 00:00:00 +0000 (UTC).
+        ///< IO_NOW = now (i.e., generate a timestamp for me).
+    const char* LE_NONNULL value
+        ///< [IN]
+);
+
+//--------------------------------------------------------------------------------------------------
+/**
+ * Push a JSON data sample.
+ */
+//--------------------------------------------------------------------------------------------------
+void io_PushJson
+(
+    const char* LE_NONNULL path,
+        ///< [IN] Resource path within the client app's namespace.
+    double timestamp,
+        ///< [IN] Timestamp in seconds since the Epoch 1970-01-01 00:00:00 +0000 (UTC).
+        ///< IO_NOW = now (i.e., generate a timestamp for me).
+    const char* LE_NONNULL value
+        ///< [IN]
+);
+
+//--------------------------------------------------------------------------------------------------
+/**
+ * Add handler function for EVENT 'io_TriggerPush'
+ */
+//--------------------------------------------------------------------------------------------------
+io_TriggerPushHandlerRef_t io_AddTriggerPushHandler
+(
+    const char* LE_NONNULL path,
+        ///< [IN] Resource path within the client app's namespace.
+    io_TriggerPushHandlerFunc_t callbackPtr,
+        ///< [IN]
+    void* contextPtr
+        ///< [IN]
+);
+
+//--------------------------------------------------------------------------------------------------
+/**
+ * Remove handler function for EVENT 'io_TriggerPush'
+ */
+//--------------------------------------------------------------------------------------------------
+void io_RemoveTriggerPushHandler
+(
+    io_TriggerPushHandlerRef_t handlerRef
+        ///< [IN]
+);
+
+//--------------------------------------------------------------------------------------------------
+/**
+ * Add handler function for EVENT 'io_BooleanPush'
+ */
+//--------------------------------------------------------------------------------------------------
+io_BooleanPushHandlerRef_t io_AddBooleanPushHandler
+(
+    const char* LE_NONNULL path,
+        ///< [IN] Resource path within the client app's namespace.
+    io_BooleanPushHandlerFunc_t callbackPtr,
+        ///< [IN]
+    void* contextPtr
+        ///< [IN]
+);
+
+//--------------------------------------------------------------------------------------------------
+/**
+ * Remove handler function for EVENT 'io_BooleanPush'
+ */
+//--------------------------------------------------------------------------------------------------
+void io_RemoveBooleanPushHandler
+(
+    io_BooleanPushHandlerRef_t handlerRef
+        ///< [IN]
+);
+
+//--------------------------------------------------------------------------------------------------
+/**
+ * Add handler function for EVENT 'io_NumericPush'
+ */
+//--------------------------------------------------------------------------------------------------
+io_NumericPushHandlerRef_t io_AddNumericPushHandler
+(
+    const char* LE_NONNULL path,
+        ///< [IN] Resource path within the client app's namespace.
+    io_NumericPushHandlerFunc_t callbackPtr,
+        ///< [IN]
+    void* contextPtr
+        ///< [IN]
+);
+
+//--------------------------------------------------------------------------------------------------
+/**
+ * Remove handler function for EVENT 'io_NumericPush'
+ */
+//--------------------------------------------------------------------------------------------------
+void io_RemoveNumericPushHandler
+(
+    io_NumericPushHandlerRef_t handlerRef
+        ///< [IN]
+);
+
+//--------------------------------------------------------------------------------------------------
+/**
+ * Add handler function for EVENT 'io_StringPush'
+ */
+//--------------------------------------------------------------------------------------------------
+io_StringPushHandlerRef_t io_AddStringPushHandler
+(
+    const char* LE_NONNULL path,
+        ///< [IN] Resource path within the client app's namespace.
+    io_StringPushHandlerFunc_t callbackPtr,
+        ///< [IN]
+    void* contextPtr
+        ///< [IN]
+);
+
+//--------------------------------------------------------------------------------------------------
+/**
+ * Remove handler function for EVENT 'io_StringPush'
+ */
+//--------------------------------------------------------------------------------------------------
+void io_RemoveStringPushHandler
+(
+    io_StringPushHandlerRef_t handlerRef
+        ///< [IN]
+);
+
+//--------------------------------------------------------------------------------------------------
+/**
+ * Add handler function for EVENT 'io_JsonPush'
+ */
+//--------------------------------------------------------------------------------------------------
+io_JsonPushHandlerRef_t io_AddJsonPushHandler
+(
+    const char* LE_NONNULL path,
+        ///< [IN] Resource path within the client app's namespace.
+    io_JsonPushHandlerFunc_t callbackPtr,
+        ///< [IN]
+    void* contextPtr
+        ///< [IN]
+);
+
+//--------------------------------------------------------------------------------------------------
+/**
+ * Remove handler function for EVENT 'io_JsonPush'
+ */
+//--------------------------------------------------------------------------------------------------
+void io_RemoveJsonPushHandler
+(
+    io_JsonPushHandlerRef_t handlerRef
+        ///< [IN]
+);
+
+//--------------------------------------------------------------------------------------------------
+/**
+ * Mark an Output resource "optional".  (By default, they are marked "mandatory".)
+ */
+//--------------------------------------------------------------------------------------------------
+void io_MarkOptional
+(
+    const char* LE_NONNULL path
+        ///< [IN] Resource path within the client app's namespace.
+);
+
+//--------------------------------------------------------------------------------------------------
+/**
+ * Set a Boolean type value as the default value of a given resource.
+ *
+ * @note This will be ignored if the resource already has a default value.
+ */
+//--------------------------------------------------------------------------------------------------
+void io_SetBooleanDefault
+(
+    const char* LE_NONNULL path,
+        ///< [IN] Resource path within the client app's namespace.
+    bool value
+        ///< [IN]
+);
+
+//--------------------------------------------------------------------------------------------------
+/**
+ * Set a numeric type value as the default value of a given resource.
+ *
+ * @note This will be ignored if the resource already has a default value.
+ */
+//--------------------------------------------------------------------------------------------------
+void io_SetNumericDefault
+(
+    const char* LE_NONNULL path,
+        ///< [IN] Resource path within the client app's namespace.
+    double value
+        ///< [IN]
+);
+
+//--------------------------------------------------------------------------------------------------
+/**
+ * Set a string type value as the default value of a given resource.
+ *
+ * @note This will be ignored if the resource already has a default value.
+ */
+//--------------------------------------------------------------------------------------------------
+void io_SetStringDefault
+(
+    const char* LE_NONNULL path,
+        ///< [IN] Resource path within the client app's namespace.
+    const char* LE_NONNULL value
+        ///< [IN]
+);
+
+//--------------------------------------------------------------------------------------------------
+/**
+ * Set a JSON type value as the default value of a given resource.
+ *
+ * @note This will be ignored if the resource already has a default value.
+ */
+//--------------------------------------------------------------------------------------------------
+void io_SetJsonDefault
+(
+    const char* LE_NONNULL path,
+        ///< [IN] Resource path within the client app's namespace.
+    const char* LE_NONNULL value
+        ///< [IN]
+);
+
+//--------------------------------------------------------------------------------------------------
+/**
+ * Fetch the timestamp of the current value of an Input or Output resource with any data type.
+ *
+ * @return
+ *  - LE_OK if successful.
+ *  - LE_NOT_FOUND if the resource does not exist.
+ *  - LE_UNAVAILABLE if the resource does not currently have a value.
+ */
+//--------------------------------------------------------------------------------------------------
+le_result_t io_GetTimestamp
+(
+    const char* LE_NONNULL path,
+        ///< [IN] Resource path within the client app's namespace.
+    double* timestampPtr
+        ///< [OUT] Timestamp in seconds since the Epoch 1970-01-01 00:00:00 +0000 (UTC).
+);
+
+//--------------------------------------------------------------------------------------------------
+/**
+ * Fetch the current value of a Boolean type Input or Output resource.
+ *
+ * @return
+ *  - LE_OK if successful.
+ *  - LE_NOT_FOUND if the resource does not exist.
+ *  - LE_UNAVAILABLE if the resource does not currently have a value.
+ */
+//--------------------------------------------------------------------------------------------------
+le_result_t io_GetBoolean
+(
+    const char* LE_NONNULL path,
+        ///< [IN] Resource path within the client app's namespace.
+    double* timestampPtr,
+        ///< [OUT] Timestamp in seconds since the Epoch 1970-01-01 00:00:00 +0000 (UTC).
+    bool* valuePtr
+        ///< [OUT]
+);
+
+//--------------------------------------------------------------------------------------------------
+/**
+ * Fetch the current value of a numeric type Input or Output resource.
+ *
+ * @return
+ *  - LE_OK if successful.
+ *  - LE_NOT_FOUND if the resource does not exist.
+ *  - LE_UNAVAILABLE if the resource does not currently have a value.
+ */
+//--------------------------------------------------------------------------------------------------
+le_result_t io_GetNumeric
+(
+    const char* LE_NONNULL path,
+        ///< [IN] Resource path within the client app's namespace.
+    double* timestampPtr,
+        ///< [OUT] Timestamp in seconds since the Epoch 1970-01-01 00:00:00 +0000 (UTC).
+    double* valuePtr
+        ///< [OUT]
+);
+
+//--------------------------------------------------------------------------------------------------
+/**
+ * Fetch the current value of a string type Input or Output resource.
+ *
+ * @return
+ *  - LE_OK if successful.
+ *  - LE_OVERFLOW if the value buffer was too small to hold the value.
+ *  - LE_NOT_FOUND if the resource does not exist.
+ *  - LE_UNAVAILABLE if the resource does not currently have a value.
+ */
+//--------------------------------------------------------------------------------------------------
+le_result_t io_GetString
+(
+    const char* LE_NONNULL path,
+        ///< [IN] Resource path within the client app's namespace.
+    double* timestampPtr,
+        ///< [OUT] Timestamp in seconds since the Epoch 1970-01-01 00:00:00 +0000 (UTC).
+    char* value,
+        ///< [OUT]
+    size_t valueSize
+        ///< [IN]
+);
+
+//--------------------------------------------------------------------------------------------------
+/**
+ * Fetch the current value of an Input or Output resource (of any data type) in JSON format.
+ *
+ * @return
+ *  - LE_OK if successful.
+ *  - LE_OVERFLOW if the value buffer was too small to hold the value.
+ *  - LE_NOT_FOUND if the resource does not exist.
+ *  - LE_UNAVAILABLE if the resource does not currently have a value.
+ */
+//--------------------------------------------------------------------------------------------------
+le_result_t io_GetJson
+(
+    const char* LE_NONNULL path,
+        ///< [IN] Resource path within the client app's namespace.
+    double* timestampPtr,
+        ///< [OUT] Timestamp in seconds since the Epoch 1970-01-01 00:00:00 +0000 (UTC).
+    char* value,
+        ///< [OUT]
+    size_t valueSize
+        ///< [IN]
+);
+
+//--------------------------------------------------------------------------------------------------
+/**
+ * Add handler function for EVENT 'io_UpdateStartEnd'
+ */
+//--------------------------------------------------------------------------------------------------
+io_UpdateStartEndHandlerRef_t io_AddUpdateStartEndHandler
+(
+    io_UpdateStartEndHandlerFunc_t callbackPtr,
+        ///< [IN]
+    void* contextPtr
+        ///< [IN]
+);
+
+//--------------------------------------------------------------------------------------------------
+/**
+ * Remove handler function for EVENT 'io_UpdateStartEnd'
+ */
+//--------------------------------------------------------------------------------------------------
+void io_RemoveUpdateStartEndHandler
+(
+    io_UpdateStartEndHandlerRef_t handlerRef
+        ///< [IN]
+);
+
+#endif // IO_INTERFACE_H_INCLUDE_GUARD

--- a/test/admin/main.c
+++ b/test/admin/main.c
@@ -1,0 +1,265 @@
+/**
+ * @file main.c
+ *
+ * unit test admin API functions:
+ *  CreateInput, CreateOutput, DeleteResource, SetJsonExample and MarkOptional
+ *
+ * Copyright (C) Sierra Wireless, Inc. Use of this work is subject to license.
+ */
+#include <stdarg.h>
+#include <stddef.h>
+#include <setjmp.h>
+#include <stdint.h>
+#include <stdlib.h>
+#include <cmocka.h>
+#include <limits.h>
+#include "interfaces.h"
+
+extern void initDataHub(void);
+
+static int setup(void **state) {
+    // Init Data Hub component
+    initDataHub();
+
+    return 0;
+}
+static int teardown(void **state) {
+    return 0;
+}
+
+/* Input resources */
+#define TEST_RESOURCES_NB 5
+static const char* ResourceName[] = {
+    "/app/app1/resource1",
+    "/app/appfoo/resourcezzzzz",
+    "/app/appfoo/resourcezzzzzz",
+    "/app/router/sensor/value",
+    "/app/dataOrchestration/trigger/value"
+};
+
+static io_DataType_t ResourceType[] = {
+    IO_DATA_TYPE_NUMERIC,
+    IO_DATA_TYPE_STRING,
+    IO_DATA_TYPE_BOOLEAN,
+    IO_DATA_TYPE_JSON,
+    IO_DATA_TYPE_TRIGGER
+};
+
+static const char* ResourceJsonExample[] = {
+    "{}",
+    "null",
+    "[]",
+    "{ \"a\" : 456}",
+    "{ \"a\" : 456, \"b\" : { \"c\" : {}}}"
+};
+
+static void test_admin_create_delete_input
+(
+    void** state
+)
+{
+    (void)state;
+    io_DataType_t dataType = IO_DATA_TYPE_TRIGGER;
+
+    // Create inputs via admin API. Check it returns OK
+    for (int i = 0 ; i < TEST_RESOURCES_NB ; i++)
+    {
+        assert_true(LE_OK == admin_CreateInput(ResourceName[i], ResourceType[i], ""));
+    }
+
+    // Check the input entry exists.
+    for (int i = 0 ; i < TEST_RESOURCES_NB ; i++)
+    {
+        assert_true(ADMIN_ENTRY_TYPE_INPUT == admin_GetEntryType(ResourceName[i]));
+    }
+    for (int i = 0 ; i < TEST_RESOURCES_NB ; i++)
+    {
+        assert_true(LE_OK == query_GetDataType(ResourceName[i], &dataType));
+        assert_true(ResourceType[i] == dataType);
+    }
+
+    // Delete the resources
+    for (int i = 0 ; i < TEST_RESOURCES_NB ; i++)
+    {
+        admin_DeleteResource(ResourceName[i]);
+    }
+
+    // Query them to confirm they are deleted
+    for (int i = 0 ; i < TEST_RESOURCES_NB ; i++)
+    {
+        assert_true(ADMIN_ENTRY_TYPE_NONE == admin_GetEntryType(ResourceName[i]));
+    }
+    for (int i = 0 ; i < TEST_RESOURCES_NB ; i++)
+    {
+        assert_true(LE_NOT_FOUND == query_GetDataType(ResourceName[i], &dataType));
+    }
+}
+
+static void test_admin_create_input_bad_path
+(
+    void** state
+)
+{
+    (void)state;
+
+    assert_true(LE_FAULT == admin_CreateInput("app/toto/value", IO_DATA_TYPE_NUMERIC, ""));
+    assert_true(LE_FAULT == admin_CreateInput("//app/toto/value", IO_DATA_TYPE_NUMERIC, ""));
+    assert_true(LE_FAULT == admin_CreateInput("/toto/value", IO_DATA_TYPE_NUMERIC, ""));
+    assert_true(LE_FAULT == admin_CreateInput("toto/value", IO_DATA_TYPE_NUMERIC, ""));
+}
+
+static void test_admin_create_input_duplicate
+(
+    void** state
+)
+{
+    (void)state;
+
+    // Create one input resource
+    assert_true(LE_OK == admin_CreateInput(ResourceName[3], ResourceType[3], ""));
+
+    // Create it again. Data Hub strategy is to return LE_OK when the resource config is identical.
+    assert_true(LE_OK == admin_CreateInput(ResourceName[3], ResourceType[3], ""));
+
+    // Create it again, but with different data type. Data Hub strategy is then to return LE_DUPLICATE
+    assert_true(LE_DUPLICATE == admin_CreateInput(ResourceName[3], ResourceType[4], ""));
+
+    // Delete resource to leave the test in a clean state
+    admin_DeleteResource(ResourceName[3]);
+}
+
+static void test_admin_create_delete_output
+(
+    void** state
+)
+{
+    (void)state;
+    io_DataType_t dataType = IO_DATA_TYPE_TRIGGER;
+
+    // Create inputs via admin API. Check it returns OK
+    for (int i = 0 ; i < TEST_RESOURCES_NB ; i++)
+    {
+        assert_true(LE_OK == admin_CreateOutput(ResourceName[i], ResourceType[i], ""));
+    }
+
+    // Check the input entry exists.
+    for (int i = 0 ; i < TEST_RESOURCES_NB ; i++)
+    {
+        assert_true(ADMIN_ENTRY_TYPE_OUTPUT == admin_GetEntryType(ResourceName[i]));
+    }
+    for (int i = 0 ; i < TEST_RESOURCES_NB ; i++)
+    {
+        assert_true(LE_OK == query_GetDataType(ResourceName[i], &dataType));
+        assert_true(ResourceType[i] == dataType);
+    }
+
+    // Delete the resources
+    for (int i = 0 ; i < TEST_RESOURCES_NB ; i++)
+    {
+        admin_DeleteResource(ResourceName[i]);
+    }
+
+    // Query them to confirm they are deleted
+    for (int i = 0 ; i < TEST_RESOURCES_NB ; i++)
+    {
+        assert_true(ADMIN_ENTRY_TYPE_NONE == admin_GetEntryType(ResourceName[i]));
+    }
+    for (int i = 0 ; i < TEST_RESOURCES_NB ; i++)
+    {
+        assert_true(LE_NOT_FOUND == query_GetDataType(ResourceName[i], &dataType));
+    }
+}
+
+static void test_admin_create_output_bad_path
+(
+    void** state
+)
+{
+    (void)state;
+
+    assert_true(LE_FAULT == admin_CreateOutput("app/toto/value", IO_DATA_TYPE_NUMERIC, ""));
+    assert_true(LE_FAULT == admin_CreateOutput("//app/toto/value", IO_DATA_TYPE_NUMERIC, ""));
+    assert_true(LE_FAULT == admin_CreateOutput("/toto/value", IO_DATA_TYPE_NUMERIC, ""));
+    assert_true(LE_FAULT == admin_CreateOutput("toto/value", IO_DATA_TYPE_NUMERIC, ""));
+}
+
+static void test_admin_create_output_duplicate
+(
+    void** state
+)
+{
+    (void)state;
+
+    // Create one input resource
+    assert_true(LE_OK == admin_CreateOutput(ResourceName[3], ResourceType[3], ""));
+
+    // Create it again. Data Hub strategy is to return LE_OK when the resource config is identical.
+    assert_true(LE_OK == admin_CreateOutput(ResourceName[3], ResourceType[3], ""));
+
+    // Create it again, but with different data type. Data Hub strategy is then to return LE_DUPLICATE
+    assert_true(LE_DUPLICATE == admin_CreateOutput(ResourceName[3], ResourceType[4], ""));
+
+    // Delete resource to leave the test in a clean state
+    admin_DeleteResource(ResourceName[3]);
+}
+
+static void test_admin_mark_optional
+(
+    void** state
+)
+{
+    (void)state;
+
+    // Works only with output
+    // If there is a an issue, it calls LE_KILL_CLIENT, test fails.
+    for (int i = 0 ; i < TEST_RESOURCES_NB ; i++)
+    {
+        assert_true(LE_OK == admin_CreateOutput(ResourceName[i], ResourceType[i], ""));
+        admin_MarkOptional(ResourceName[i]);
+    }
+
+    // Delete resources to leave the test in a clean state
+    for (int i = 0 ; i < TEST_RESOURCES_NB ; i++)
+    {
+        admin_DeleteResource(ResourceName[i]);
+    }
+}
+
+static void test_admin_set_json_example
+(
+    void** state
+)
+{
+    (void)state;
+
+    // Works only with Input resources.
+    for (int i = 0 ; i < TEST_RESOURCES_NB ; i++)
+    {
+        assert_true(LE_OK == admin_CreateInput(ResourceName[i], IO_DATA_TYPE_JSON, ""));
+        admin_SetJsonExample(ResourceName[i], ResourceJsonExample[i]);
+    }
+
+    // Delete resources to leave the test in a clean state
+    for (int i = 0 ; i < TEST_RESOURCES_NB ; i++)
+    {
+        admin_DeleteResource(ResourceName[i]);
+    }
+}
+
+int main(int argc, char **argv)
+{
+    (void)argc;
+    (void)argv;
+    const struct CMUnitTest tests[] =
+    {
+        cmocka_unit_test(test_admin_create_delete_input),
+        cmocka_unit_test(test_admin_create_input_bad_path),
+        cmocka_unit_test(test_admin_create_input_duplicate),
+        cmocka_unit_test(test_admin_create_delete_output),
+        cmocka_unit_test(test_admin_create_output_bad_path),
+        cmocka_unit_test(test_admin_create_output_duplicate),
+        cmocka_unit_test(test_admin_mark_optional),
+        cmocka_unit_test(test_admin_set_json_example)
+    };
+    return cmocka_run_group_tests(tests, setup, teardown);
+}

--- a/test/admin/mock.c
+++ b/test/admin/mock.c
@@ -1,0 +1,46 @@
+#include "legato.h"
+
+char* simulateAppName;
+
+//--------------------------------------------------------------------------------------------------
+/**
+ * Get the client session reference for the current message
+ */
+//--------------------------------------------------------------------------------------------------
+struct le_msg_Session
+{
+    enum
+    {
+        LE_MSG_SESSION_UNIX_SOCKET,
+        LE_MSG_SESSION_LOCAL
+    } type;
+};
+
+struct le_msg_Session sessionIo;
+le_msg_SessionRef_t io_GetClientSessionRef(void)
+{
+    sessionIo.type = LE_MSG_SESSION_LOCAL;
+    le_msg_SessionRef_t sessionRef = &sessionIo;
+    return sessionRef;
+}
+
+struct le_msg_Session sessionQuery;
+le_msg_SessionRef_t query_GetClientSessionRef(void)
+{
+    sessionQuery.type = LE_MSG_SESSION_LOCAL;
+    le_msg_SessionRef_t sessionRef = &sessionQuery;
+    return sessionRef;
+}
+
+le_result_t le_appInfo_GetName
+(
+    int32_t  pid,           ///< [IN]  PID of the process.
+    char    *appNameStr,    ///< [OUT] Application name buffer.
+    size_t   appNameSize    ///< [IN]  Buffer size.
+)
+{
+    (void)pid;
+    (void)appNameSize;
+    strcpy(appNameStr, simulateAppName);
+    return LE_OK;
+}

--- a/test/admin/query_common.h
+++ b/test/admin/query_common.h
@@ -1,0 +1,874 @@
+
+/*
+ * ====================== WARNING ======================
+ *
+ * THE CONTENTS OF THIS FILE HAVE BEEN AUTO-GENERATED.
+ * DO NOT MODIFY IN ANY WAY.
+ *
+ * ====================== WARNING ======================
+ */
+#ifndef QUERY_COMMON_H_INCLUDE_GUARD
+#define QUERY_COMMON_H_INCLUDE_GUARD
+
+
+#include "legato.h"
+
+// Interface specific includes
+#include "io_common.h"
+
+#define IFGEN_QUERY_PROTOCOL_ID "bddfa3a9a8e7e2216b61441a8dc6f987"
+#define IFGEN_QUERY_MSG_SIZE 50024
+
+
+
+//--------------------------------------------------------------------------------------------------
+/**
+ */
+//--------------------------------------------------------------------------------------------------
+#define QUERY_BEGINNING_OF_TIME 0
+
+//--------------------------------------------------------------------------------------------------
+/**
+ * Reference type used by Add/Remove functions for EVENT 'query_TriggerPush'
+ */
+//--------------------------------------------------------------------------------------------------
+typedef struct query_TriggerPushHandler* query_TriggerPushHandlerRef_t;
+
+
+//--------------------------------------------------------------------------------------------------
+/**
+ * Reference type used by Add/Remove functions for EVENT 'query_BooleanPush'
+ */
+//--------------------------------------------------------------------------------------------------
+typedef struct query_BooleanPushHandler* query_BooleanPushHandlerRef_t;
+
+
+//--------------------------------------------------------------------------------------------------
+/**
+ * Reference type used by Add/Remove functions for EVENT 'query_NumericPush'
+ */
+//--------------------------------------------------------------------------------------------------
+typedef struct query_NumericPushHandler* query_NumericPushHandlerRef_t;
+
+
+//--------------------------------------------------------------------------------------------------
+/**
+ * Reference type used by Add/Remove functions for EVENT 'query_StringPush'
+ */
+//--------------------------------------------------------------------------------------------------
+typedef struct query_StringPushHandler* query_StringPushHandlerRef_t;
+
+
+//--------------------------------------------------------------------------------------------------
+/**
+ * Reference type used by Add/Remove functions for EVENT 'query_JsonPush'
+ */
+//--------------------------------------------------------------------------------------------------
+typedef struct query_JsonPushHandler* query_JsonPushHandlerRef_t;
+
+
+//--------------------------------------------------------------------------------------------------
+/**
+ */
+//--------------------------------------------------------------------------------------------------
+typedef enum
+{
+    QUERY_SNAPSHOT_FORMAT_JSON = 0,
+        ///< Basic JSON representation of the resource tree.
+    QUERY_SNAPSHOT_FORMAT_OCTAVE = 1,
+        ///< Format for the payload of an Octave "tree" or "tree-diff" message.
+    QUERY_SNAPSHOT_FORMAT_CUSTOM = 2
+        ///< First available custom format type value.
+}
+query_SnapshotFormat_t;
+
+
+//--------------------------------------------------------------------------------------------------
+/**
+ */
+//--------------------------------------------------------------------------------------------------/// After taking this snapshot, flush accumulated deletion
+/// records.
+#define QUERY_SNAPSHOT_FLAG_FLUSH_DELETIONS 0x1/// First available custom control flag.
+#define QUERY_SNAPSHOT_FLAG_CUSTOM 0x2
+typedef uint32_t query_SnapshotFlag_t;
+
+
+//--------------------------------------------------------------------------------------------------
+/**
+ * Completion callbacks for query_ReadBufferJson() must look like this.
+ */
+//--------------------------------------------------------------------------------------------------
+typedef void (*query_ReadCompletionFunc_t)
+(
+        le_result_t result,
+        ///< LE_OK if successful, LE_COMM_ERROR if write to outputFile failed.
+        void* contextPtr
+        ///<
+);
+
+//--------------------------------------------------------------------------------------------------
+/**
+ * Callback function for pushing triggers to an output
+ */
+//--------------------------------------------------------------------------------------------------
+typedef void (*query_TriggerPushHandlerFunc_t)
+(
+        double timestamp,
+        ///< Timestamp in seconds since the Epoch 1970-01-01 00:00:00 +0000 (UTC).
+        void* contextPtr
+        ///<
+);
+
+//--------------------------------------------------------------------------------------------------
+/**
+ * Callback function for pushing Boolean values to an output
+ */
+//--------------------------------------------------------------------------------------------------
+typedef void (*query_BooleanPushHandlerFunc_t)
+(
+        double timestamp,
+        ///< Timestamp in seconds since the Epoch 1970-01-01 00:00:00 +0000 (UTC).
+        bool value,
+        ///<
+        void* contextPtr
+        ///<
+);
+
+//--------------------------------------------------------------------------------------------------
+/**
+ * Callback function for pushing numeric values to an output
+ */
+//--------------------------------------------------------------------------------------------------
+typedef void (*query_NumericPushHandlerFunc_t)
+(
+        double timestamp,
+        ///< Timestamp in seconds since the Epoch 1970-01-01 00:00:00 +0000 (UTC).
+        double value,
+        ///<
+        void* contextPtr
+        ///<
+);
+
+//--------------------------------------------------------------------------------------------------
+/**
+ * Callback function for pushing string values to an output
+ */
+//--------------------------------------------------------------------------------------------------
+typedef void (*query_StringPushHandlerFunc_t)
+(
+        double timestamp,
+        ///< Timestamp in seconds since the Epoch 1970-01-01 00:00:00 +0000 (UTC).
+        const char* LE_NONNULL value,
+        ///<
+        void* contextPtr
+        ///<
+);
+
+//--------------------------------------------------------------------------------------------------
+/**
+ * Callback function for pushing JSON values to an output
+ */
+//--------------------------------------------------------------------------------------------------
+typedef void (*query_JsonPushHandlerFunc_t)
+(
+        double timestamp,
+        ///< Timestamp in seconds since the Epoch 1970-01-01 00:00:00 +0000 (UTC).
+        const char* LE_NONNULL value,
+        ///<
+        void* contextPtr
+        ///<
+);
+
+//--------------------------------------------------------------------------------------------------
+/**
+ */
+//--------------------------------------------------------------------------------------------------
+typedef void (*query_HandleSnapshotResultFunc_t)
+(
+        le_result_t status,
+        ///< LE_OK when content is complete. Any other value indicates an error.
+        void* contextPtr
+        ///<
+);
+
+
+//--------------------------------------------------------------------------------------------------
+/**
+ * Get if this client bound locally.
+ */
+//--------------------------------------------------------------------------------------------------
+LE_SHARED bool ifgen_query_HasLocalBinding
+(
+    void
+);
+
+
+//--------------------------------------------------------------------------------------------------
+/**
+ * Init data that is common across all threads
+ */
+//--------------------------------------------------------------------------------------------------
+LE_SHARED void ifgen_query_InitCommonData
+(
+    void
+);
+
+
+//--------------------------------------------------------------------------------------------------
+/**
+ * Perform common initialization and open a session
+ */
+//--------------------------------------------------------------------------------------------------
+LE_SHARED le_result_t ifgen_query_OpenSession
+(
+    le_msg_SessionRef_t _ifgen_sessionRef,
+    bool isBlocking
+);
+
+//--------------------------------------------------------------------------------------------------
+/**
+ * Read data out of a buffer.  Data is written to a given file descriptor in JSON-encoded format
+ * as an array of objects containing a timestamp and a value (or just a timestamp for triggers).
+ * E.g.,
+ *
+ * @code
+ * [{"t":1537483647.125,"v":true},{"t":1537483657.128,"v":true}]
+ * @endcode
+ *
+ * @return
+ *  - LE_OK if the read operation started successfully.
+ *  - LE_NOT_FOUND if the Observation doesn't exist.
+ */
+//--------------------------------------------------------------------------------------------------
+LE_SHARED le_result_t ifgen_query_ReadBufferJson
+(
+    le_msg_SessionRef_t _ifgen_sessionRef,
+        const char* LE_NONNULL obsPath,
+        ///< [IN] Observation path. Can be absolute
+        ///< (beginning with a '/') or relative to /obs/.
+        double startAfter,
+        ///< [IN] Start after this many seconds ago,
+        ///< or after an absolute number of seconds since the Epoch
+        ///< (if startafter > 30 years).
+        ///< Use NAN (not a number) to read the whole buffer.
+        int outputFile,
+        ///< [IN] File descriptor to write the data to.
+        query_ReadCompletionFunc_t completionFuncPtr,
+        ///< [IN] Completion callback to be called when operation finishes.
+        void* contextPtr
+        ///< [IN]
+);
+
+//--------------------------------------------------------------------------------------------------
+/**
+ * Read the timestamp of a single sample from a buffer.
+ *
+ * @note This can be used with any type of sample.
+ *
+ * @return
+ *  - LE_OK if successful.
+ *  - LE_NOT_FOUND if the Observation doesn't exist or does not have a sample newer than the given
+ *                 startAfter timestamp.
+ */
+//--------------------------------------------------------------------------------------------------
+LE_SHARED le_result_t ifgen_query_ReadBufferSampleTimestamp
+(
+    le_msg_SessionRef_t _ifgen_sessionRef,
+        const char* LE_NONNULL obsPath,
+        ///< [IN] Observation path. Can be absolute
+        ///< (beginning with a '/') or relative to /obs/.
+        double startAfter,
+        ///< [IN] Start after this many seconds ago,
+        ///< or after an absolute number of seconds since the Epoch
+        ///< (if startafter > 30 years).
+        ///< Use NAN (not a number) to read the oldest sample in the buffer.
+        double* timestampPtr
+        ///< [OUT] Timestamp of the sample, if LE_OK returned.
+);
+
+//--------------------------------------------------------------------------------------------------
+/**
+ * Read a single Boolean sample from a buffer.
+ *
+ * @warning This can only be used with Boolean type samples.
+ *
+ * @return
+ *  - LE_OK if successful.
+ *  - LE_NOT_FOUND if the Observation doesn't exist or does not have a Boolean sample newer than
+ *                 the given startAfter timestamp.
+ */
+//--------------------------------------------------------------------------------------------------
+LE_SHARED le_result_t ifgen_query_ReadBufferSampleBoolean
+(
+    le_msg_SessionRef_t _ifgen_sessionRef,
+        const char* LE_NONNULL obsPath,
+        ///< [IN] Observation path. Can be absolute
+        ///< (beginning with a '/') or relative to /obs/.
+        double startAfter,
+        ///< [IN] Start after this many seconds ago,
+        ///< or after an absolute number of seconds since the Epoch
+        ///< (if startafter > 30 years).
+        ///< Use NAN (not a number) to read the oldest sample in the buffer.
+        double* timestampPtr,
+        ///< [OUT] Timestamp of the sample, if LE_OK returned.
+        bool* valuePtr
+        ///< [OUT] Value of the sample, if LE_OK returned.
+);
+
+//--------------------------------------------------------------------------------------------------
+/**
+ * Read a single numeric sample from a buffer.
+ *
+ * @warning This can only be used with numeric type samples.
+ *
+ * @return
+ *  - LE_OK if successful.
+ *  - LE_NOT_FOUND if the Observation doesn't exist or does not have a Numeric sample newer than
+ *                 the given startAfter timestamp.
+ */
+//--------------------------------------------------------------------------------------------------
+LE_SHARED le_result_t ifgen_query_ReadBufferSampleNumeric
+(
+    le_msg_SessionRef_t _ifgen_sessionRef,
+        const char* LE_NONNULL obsPath,
+        ///< [IN] Observation path. Can be absolute
+        ///< (beginning with a '/') or relative to /obs/.
+        double startAfter,
+        ///< [IN] Start after this many seconds ago,
+        ///< or after an absolute number of seconds since the Epoch
+        ///< (if startafter > 30 years).
+        ///< Use NAN (not a number) to read the oldest sample in the buffer.
+        double* timestampPtr,
+        ///< [OUT] Timestamp of the sample, if LE_OK returned.
+        double* valuePtr
+        ///< [OUT] Value of the sample, if LE_OK returned.
+);
+
+//--------------------------------------------------------------------------------------------------
+/**
+ * Read a single sample from a buffer as a string.
+ *
+ * @note This can be used with any type of sample.
+ *
+ * @return
+ *  - LE_OK if successful.
+ *  - LE_NOT_FOUND if the Observation doesn't exist or does not have a sample newer than the given
+ *                 startAfter timestamp.
+ *  - LE_OVERFLOW if the buffer provided is too small to hold the value.
+ */
+//--------------------------------------------------------------------------------------------------
+LE_SHARED le_result_t ifgen_query_ReadBufferSampleString
+(
+    le_msg_SessionRef_t _ifgen_sessionRef,
+        const char* LE_NONNULL obsPath,
+        ///< [IN] Observation path. Can be absolute
+        ///< (beginning with a '/') or relative to /obs/.
+        double startAfter,
+        ///< [IN] Start after this many seconds ago,
+        ///< or after an absolute number of seconds since the Epoch
+        ///< (if startafter > 30 years).
+        ///< Use NAN (not a number) to read the oldest sample in the buffer.
+        double* timestampPtr,
+        ///< [OUT] Timestamp of the sample, if LE_OK returned.
+        char* value,
+        ///< [OUT] Value of the sample, if LE_OK returned.
+        size_t valueSize
+        ///< [IN]
+);
+
+//--------------------------------------------------------------------------------------------------
+/**
+ * Read a single sample from a buffer as JSON.
+ *
+ * @note This can be used with any type of sample.
+ *
+ * @return
+ *  - LE_OK if successful.
+ *  - LE_NOT_FOUND if the Observation doesn't exist or does not have a sample newer than the given
+ *                 startAfter timestamp.
+ *  - LE_OVERFLOW if the buffer provided is too small to hold the value.
+ */
+//--------------------------------------------------------------------------------------------------
+LE_SHARED le_result_t ifgen_query_ReadBufferSampleJson
+(
+    le_msg_SessionRef_t _ifgen_sessionRef,
+        const char* LE_NONNULL obsPath,
+        ///< [IN] Observation path. Can be absolute
+        ///< (beginning with a '/') or relative to /obs/.
+        double startAfter,
+        ///< [IN] Start after this many seconds ago,
+        ///< or after an absolute number of seconds since the Epoch
+        ///< (if startafter > 30 years).
+        ///< Use NAN (not a number) to read the oldest sample in the buffer.
+        double* timestampPtr,
+        ///< [OUT] Timestamp of the sample, if LE_OK returned.
+        char* value,
+        ///< [OUT] Value of the sample, if LE_OK returned.
+        size_t valueSize
+        ///< [IN]
+);
+
+//--------------------------------------------------------------------------------------------------
+/**
+ * Get the minimum value found in an Observation's data set within a given time span.
+ *
+ * @return The value, or NAN (not-a-number) if there's no numerical data in the Observation's
+ *         buffer (if the buffer size is zero, the buffer is empty, or the buffer contains data
+ *         of a non-numerical type).
+ */
+//--------------------------------------------------------------------------------------------------
+LE_SHARED double ifgen_query_GetMin
+(
+    le_msg_SessionRef_t _ifgen_sessionRef,
+        const char* LE_NONNULL obsPath,
+        ///< [IN] Observation path. Can be absolute
+        ///< (beginning with a '/') or relative to /obs/.
+        double startTime
+        ///< [IN] If < 30 years then seconds before now; else seconds since the Epoch.
+);
+
+//--------------------------------------------------------------------------------------------------
+/**
+ * Get the maximum value found within a given time span in an Observation's buffer.
+ *
+ * @return The value, or NAN (not-a-number) if there's no numerical data in the Observation's
+ *         buffer (if the buffer size is zero, the buffer is empty, or the buffer contains data
+ *         of a non-numerical type).
+ */
+//--------------------------------------------------------------------------------------------------
+LE_SHARED double ifgen_query_GetMax
+(
+    le_msg_SessionRef_t _ifgen_sessionRef,
+        const char* LE_NONNULL obsPath,
+        ///< [IN] Observation path. Can be absolute
+        ///< (beginning with a '/') or relative to /obs/.
+        double startTime
+        ///< [IN] If < 30 years then seconds before now; else seconds since the Epoch.
+);
+
+//--------------------------------------------------------------------------------------------------
+/**
+ * Get the mean (average) of all values found within a given time span in an Observation's buffer.
+ *
+ * @return The value, or NAN (not-a-number) if there's no numerical data in the Observation's
+ *         buffer (if the buffer size is zero, the buffer is empty, or the buffer contains data
+ *         of a non-numerical type).
+ */
+//--------------------------------------------------------------------------------------------------
+LE_SHARED double ifgen_query_GetMean
+(
+    le_msg_SessionRef_t _ifgen_sessionRef,
+        const char* LE_NONNULL obsPath,
+        ///< [IN] Observation path. Can be absolute
+        ///< (beginning with a '/') or relative to /obs/.
+        double startTime
+        ///< [IN] If < 30 years then seconds before now; else seconds since the Epoch.
+);
+
+//--------------------------------------------------------------------------------------------------
+/**
+ * Get the standard deviation of all values found within a given time span in an
+ * Observation's buffer.
+ *
+ * @return The value, or NAN (not-a-number) if there's no numerical data in the Observation's
+ *         buffer (if the buffer size is zero, the buffer is empty, or the buffer contains data
+ *         of a non-numerical type).
+ */
+//--------------------------------------------------------------------------------------------------
+LE_SHARED double ifgen_query_GetStdDev
+(
+    le_msg_SessionRef_t _ifgen_sessionRef,
+        const char* LE_NONNULL obsPath,
+        ///< [IN] Observation path. Can be absolute
+        ///< (beginning with a '/') or relative to /obs/.
+        double startTime
+        ///< [IN] If < 30 years then seconds before now; else seconds since the Epoch.
+);
+
+//--------------------------------------------------------------------------------------------------
+/**
+ * Get the current data type of a resource.
+ *
+ * @note Observations and Placeholders will default to IO_DATA_TYPE_TRIGGER, but will change
+ *       types as other types of data are pushed to them.  The data types of Inputs and Outputs
+ *       are decided by the apps that create them.
+ *
+ * @return
+ *  - LE_OK if successful.
+ *  - LE_NOT_FOUND if the resource was not found.
+ *  - LE_UNSUPPORTED if the path refers to a namespace (which can't have a data type).
+ */
+//--------------------------------------------------------------------------------------------------
+LE_SHARED le_result_t ifgen_query_GetDataType
+(
+    le_msg_SessionRef_t _ifgen_sessionRef,
+        const char* LE_NONNULL path,
+        ///< [IN] Resource path. Can be absolute (beginning
+        ///< with a '/') or relative to the namespace of
+        ///< the calling app (/app/<app-name>/).
+        io_DataType_t* dataTypePtr
+        ///< [OUT] The fetched data type, if LE_OK is returned.
+);
+
+//--------------------------------------------------------------------------------------------------
+/**
+ * Get the current units of a resource.
+ *
+ * @note Observations and Placeholders will default to "", but will change units as data is
+ *       pushed to them.  The units of Inputs and Outputs are decided by the apps that create them.
+ *
+ * @return
+ *  - LE_OK if successful.
+ *  - LE_NOT_FOUND if the resource was not found.
+ *  - LE_UNSUPPORTED if the path refers to a namespace (which can't have a data type).
+ *  - LE_OVERFLOW if the units string was truncated because it is larger than the buffer provided.
+ */
+//--------------------------------------------------------------------------------------------------
+LE_SHARED le_result_t ifgen_query_GetUnits
+(
+    le_msg_SessionRef_t _ifgen_sessionRef,
+        const char* LE_NONNULL path,
+        ///< [IN] Resource path. Can be absolute (beginning
+        ///< with a '/') or relative to the namespace of
+        ///< the calling app (/app/<app-name>/).
+        char* units,
+        ///< [OUT] The fetched units, if LE_OK is returned.
+        size_t unitsSize
+        ///< [IN]
+);
+
+//--------------------------------------------------------------------------------------------------
+/**
+ * Get the timestamp of the current value of a resource.
+ *
+ * @return
+ *  - LE_OK if successful.
+ *  - LE_NOT_FOUND if the resource was not found.
+ *  - LE_UNSUPPORTED if the path refers to a namespace (which can't have a data type).
+ *  - LE_UNAVAILABLE if the resource doesn't have a current value (yet).
+ */
+//--------------------------------------------------------------------------------------------------
+LE_SHARED le_result_t ifgen_query_GetTimestamp
+(
+    le_msg_SessionRef_t _ifgen_sessionRef,
+        const char* LE_NONNULL path,
+        ///< [IN] Resource path. Can be absolute (beginning
+        ///< with a '/') or relative to the namespace of
+        ///< the calling app (/app/<app-name>/).
+        double* timestampPtr
+        ///< [OUT] The fetched timestamp (in seconds since the Epoch), if LE_OK returned.
+);
+
+//--------------------------------------------------------------------------------------------------
+/**
+ * Get the current value of a resource, if it's Boolean type.
+ *
+ * @return
+ *  - LE_OK if successful.
+ *  - LE_NOT_FOUND if the resource was not found.
+ *  - LE_UNSUPPORTED if the path refers to a namespace (which can't have a data type).
+ *  - LE_UNAVAILABLE if the resource doesn't have a current value (yet).
+ *  - LE_FORMAT_ERROR if the resource has another data type.
+ */
+//--------------------------------------------------------------------------------------------------
+LE_SHARED le_result_t ifgen_query_GetBoolean
+(
+    le_msg_SessionRef_t _ifgen_sessionRef,
+        const char* LE_NONNULL path,
+        ///< [IN] Resource path. Can be absolute (beginning
+        ///< with a '/') or relative to the namespace of
+        ///< the calling app (/app/<app-name>/).
+        double* timestampPtr,
+        ///< [OUT] Fetched timestamp (in seconds since the Epoch), if LE_OK returned.
+        bool* valuePtr
+        ///< [OUT] Fetched value, if LE_OK returned.
+);
+
+//--------------------------------------------------------------------------------------------------
+/**
+ * Get the current value of a resource, if it's numeric type.
+ *
+ * @return
+ *  - LE_OK if successful.
+ *  - LE_NOT_FOUND if the resource was not found.
+ *  - LE_UNSUPPORTED if the path refers to a namespace (which can't have a data type).
+ *  - LE_UNAVAILABLE if the resource doesn't have a current value (yet).
+ *  - LE_FORMAT_ERROR if the resource has another data type.
+ */
+//--------------------------------------------------------------------------------------------------
+LE_SHARED le_result_t ifgen_query_GetNumeric
+(
+    le_msg_SessionRef_t _ifgen_sessionRef,
+        const char* LE_NONNULL path,
+        ///< [IN] Resource path. Can be absolute (beginning
+        ///< with a '/') or relative to the namespace of
+        ///< the calling app (/app/<app-name>/).
+        double* timestampPtr,
+        ///< [OUT] Fetched timestamp (in seconds since the Epoch), if LE_OK returned.
+        double* valuePtr
+        ///< [OUT] Fetched value, if LE_OK returned.
+);
+
+//--------------------------------------------------------------------------------------------------
+/**
+ * Get the current value of a resource, if it's a string type.
+ *
+ * @return
+ *  - LE_OK if successful.
+ *  - LE_NOT_FOUND if the resource was not found.
+ *  - LE_UNSUPPORTED if the path refers to a namespace (which can't have a data type).
+ *  - LE_UNAVAILABLE if the resource doesn't have a current value (yet).
+ *  - LE_FORMAT_ERROR if the resource has another data type.
+ *  - LE_OVERFLOW if the value was truncated because it is larger than the buffer provided.
+ */
+//--------------------------------------------------------------------------------------------------
+LE_SHARED le_result_t ifgen_query_GetString
+(
+    le_msg_SessionRef_t _ifgen_sessionRef,
+        const char* LE_NONNULL path,
+        ///< [IN] Resource path. Can be absolute (beginning
+        ///< with a '/') or relative to the namespace of
+        ///< the calling app (/app/<app-name>/).
+        double* timestampPtr,
+        ///< [OUT] Fetched timestamp (in seconds since the Epoch), if LE_OK returned.
+        char* value,
+        ///< [OUT] Fetched value, if LE_OK returned.
+        size_t valueSize
+        ///< [IN]
+);
+
+//--------------------------------------------------------------------------------------------------
+/**
+ * Get the current value of a resource of any type, in JSON format.
+ *
+ * @return
+ *  - LE_OK if successful.
+ *  - LE_NOT_FOUND if the resource was not found.
+ *  - LE_UNSUPPORTED if the path refers to a namespace (which can't have a data type).
+ *  - LE_UNAVAILABLE if the resource doesn't have a current value (yet).
+ *  - LE_OVERFLOW if the value was truncated because it is larger than the buffer provided.
+ */
+//--------------------------------------------------------------------------------------------------
+LE_SHARED le_result_t ifgen_query_GetJson
+(
+    le_msg_SessionRef_t _ifgen_sessionRef,
+        const char* LE_NONNULL path,
+        ///< [IN] Resource path. Can be absolute (beginning
+        ///< with a '/') or relative to the namespace of
+        ///< the calling app (/app/<app-name>/).
+        double* timestampPtr,
+        ///< [OUT] Fetched timestamp (in seconds since the Epoch), if LE_OK returned.
+        char* value,
+        ///< [OUT] Fetched value, if LE_OK returned.
+        size_t valueSize
+        ///< [IN]
+);
+
+//--------------------------------------------------------------------------------------------------
+/**
+ * Fetch the example JSON value string for a given Input resource.
+ *
+ * @return
+ *  - LE_OK if successful.
+ *  - LE_NOT_FOUND if the resource was not found.
+ *  - LE_UNSUPPORTED if the path refers to something that doesn't have a JSON type.
+ *  - LE_UNAVAILABLE if the JSON-type resource doesn't have an example value.
+ *  - LE_OVERFLOW if the value was truncated because it is larger than the buffer provided.
+ */
+//--------------------------------------------------------------------------------------------------
+LE_SHARED le_result_t ifgen_query_GetJsonExample
+(
+    le_msg_SessionRef_t _ifgen_sessionRef,
+        const char* LE_NONNULL path,
+        ///< [IN] Resource path. Can be absolute (beginning
+        ///< with a '/') or relative to the namespace of
+        ///< the calling app (/app/<app-name>/).
+        char* example,
+        ///< [OUT] Example will be put here, if LE_OK returned.
+        size_t exampleSize
+        ///< [IN]
+);
+
+//--------------------------------------------------------------------------------------------------
+/**
+ * Add handler function for EVENT 'query_TriggerPush'
+ */
+//--------------------------------------------------------------------------------------------------
+LE_SHARED query_TriggerPushHandlerRef_t ifgen_query_AddTriggerPushHandler
+(
+    le_msg_SessionRef_t _ifgen_sessionRef,
+        const char* LE_NONNULL path,
+        ///< [IN] Absolute path of resource.
+        query_TriggerPushHandlerFunc_t callbackPtr,
+        ///< [IN]
+        void* contextPtr
+        ///< [IN]
+);
+
+//--------------------------------------------------------------------------------------------------
+/**
+ * Remove handler function for EVENT 'query_TriggerPush'
+ */
+//--------------------------------------------------------------------------------------------------
+LE_SHARED void ifgen_query_RemoveTriggerPushHandler
+(
+    le_msg_SessionRef_t _ifgen_sessionRef,
+        query_TriggerPushHandlerRef_t handlerRef
+        ///< [IN]
+);
+
+//--------------------------------------------------------------------------------------------------
+/**
+ * Add handler function for EVENT 'query_BooleanPush'
+ */
+//--------------------------------------------------------------------------------------------------
+LE_SHARED query_BooleanPushHandlerRef_t ifgen_query_AddBooleanPushHandler
+(
+    le_msg_SessionRef_t _ifgen_sessionRef,
+        const char* LE_NONNULL path,
+        ///< [IN] Absolute path of resource.
+        query_BooleanPushHandlerFunc_t callbackPtr,
+        ///< [IN]
+        void* contextPtr
+        ///< [IN]
+);
+
+//--------------------------------------------------------------------------------------------------
+/**
+ * Remove handler function for EVENT 'query_BooleanPush'
+ */
+//--------------------------------------------------------------------------------------------------
+LE_SHARED void ifgen_query_RemoveBooleanPushHandler
+(
+    le_msg_SessionRef_t _ifgen_sessionRef,
+        query_BooleanPushHandlerRef_t handlerRef
+        ///< [IN]
+);
+
+//--------------------------------------------------------------------------------------------------
+/**
+ * Add handler function for EVENT 'query_NumericPush'
+ */
+//--------------------------------------------------------------------------------------------------
+LE_SHARED query_NumericPushHandlerRef_t ifgen_query_AddNumericPushHandler
+(
+    le_msg_SessionRef_t _ifgen_sessionRef,
+        const char* LE_NONNULL path,
+        ///< [IN] Absolute path of resource.
+        query_NumericPushHandlerFunc_t callbackPtr,
+        ///< [IN]
+        void* contextPtr
+        ///< [IN]
+);
+
+//--------------------------------------------------------------------------------------------------
+/**
+ * Remove handler function for EVENT 'query_NumericPush'
+ */
+//--------------------------------------------------------------------------------------------------
+LE_SHARED void ifgen_query_RemoveNumericPushHandler
+(
+    le_msg_SessionRef_t _ifgen_sessionRef,
+        query_NumericPushHandlerRef_t handlerRef
+        ///< [IN]
+);
+
+//--------------------------------------------------------------------------------------------------
+/**
+ * Add handler function for EVENT 'query_StringPush'
+ */
+//--------------------------------------------------------------------------------------------------
+LE_SHARED query_StringPushHandlerRef_t ifgen_query_AddStringPushHandler
+(
+    le_msg_SessionRef_t _ifgen_sessionRef,
+        const char* LE_NONNULL path,
+        ///< [IN] Absolute path of resource.
+        query_StringPushHandlerFunc_t callbackPtr,
+        ///< [IN]
+        void* contextPtr
+        ///< [IN]
+);
+
+//--------------------------------------------------------------------------------------------------
+/**
+ * Remove handler function for EVENT 'query_StringPush'
+ */
+//--------------------------------------------------------------------------------------------------
+LE_SHARED void ifgen_query_RemoveStringPushHandler
+(
+    le_msg_SessionRef_t _ifgen_sessionRef,
+        query_StringPushHandlerRef_t handlerRef
+        ///< [IN]
+);
+
+//--------------------------------------------------------------------------------------------------
+/**
+ * Add handler function for EVENT 'query_JsonPush'
+ */
+//--------------------------------------------------------------------------------------------------
+LE_SHARED query_JsonPushHandlerRef_t ifgen_query_AddJsonPushHandler
+(
+    le_msg_SessionRef_t _ifgen_sessionRef,
+        const char* LE_NONNULL path,
+        ///< [IN] Absolute path of resource.
+        query_JsonPushHandlerFunc_t callbackPtr,
+        ///< [IN]
+        void* contextPtr
+        ///< [IN]
+);
+
+//--------------------------------------------------------------------------------------------------
+/**
+ * Remove handler function for EVENT 'query_JsonPush'
+ */
+//--------------------------------------------------------------------------------------------------
+LE_SHARED void ifgen_query_RemoveJsonPushHandler
+(
+    le_msg_SessionRef_t _ifgen_sessionRef,
+        query_JsonPushHandlerRef_t handlerRef
+        ///< [IN]
+);
+
+//--------------------------------------------------------------------------------------------------
+/**
+ */
+//--------------------------------------------------------------------------------------------------
+LE_SHARED void ifgen_query_TakeSnapshot
+(
+    le_msg_SessionRef_t _ifgen_sessionRef,
+        uint32_t format,
+        ///< [IN] Snapshot output data format.
+        query_SnapshotFlag_t flags,
+        ///< [IN] Flags controlling the
+        ///< snapshot action.
+        const char* LE_NONNULL path,
+        ///< [IN] Tree path to use as the root.
+        double since,
+        ///< [IN] Request only values that have
+        ///< changed since this time (in s).
+        ///< Use BEGINNING_OF_TIME to
+        ///< request the full tree.
+        query_HandleSnapshotResultFunc_t callbackPtr,
+        ///< [IN] Completion callback to indicate
+        ///< the end of the streamed
+        ///< snapshot, or an error.
+        void* contextPtr,
+        ///< [IN]
+        int* snapshotStreamPtr
+        ///< [OUT] File descriptor to which the
+        ///< encoded snapshot data will be
+        ///< streamed.
+);
+
+//--------------------------------------------------------------------------------------------------
+/**
+ */
+//--------------------------------------------------------------------------------------------------
+LE_SHARED void ifgen_query_TrackDeletions
+(
+    le_msg_SessionRef_t _ifgen_sessionRef,
+        bool on
+        ///< [IN] If true, start tracking deletions; if false stop tracking and flush records.
+);
+
+#endif // QUERY_COMMON_H_INCLUDE_GUARD

--- a/test/admin/query_interface.h
+++ b/test/admin/query_interface.h
@@ -1,0 +1,904 @@
+
+
+/*
+ * ====================== WARNING ======================
+ *
+ * THE CONTENTS OF THIS FILE HAVE BEEN AUTO-GENERATED.
+ * DO NOT MODIFY IN ANY WAY.
+ *
+ * ====================== WARNING ======================
+ */
+
+/**
+ * @page c_dataHubQuery Data Hub Query API
+ *
+ * @ref query_interface.h "API Reference"
+ *
+ * The Data Hub Query API provides its clients with the ability to query resources within the
+ * Data Hub's resource tree.
+ *
+ * There are three types of query supported:
+ * - Fetching of values
+ * - Statistical analysis of buffered data sets
+ * - Fetching of versioned snapshots of all or part of the resource tree.
+ *
+ *
+ * @section c_dataHubQuery_Fetching Fetching Data
+ *
+ * All resources in the Data Hub's resource tree, including Inputs, Outputs, and Observations,
+ * have a "current value", which is the last value accepted by the resource. All resources can have
+ * their current value fetched using one of the following functions:
+ *  - query_GetDataType() - get the current data type of the resource (could be unknown)
+ *  - query_GetUnits() - get the resource's units (could be unspecified)
+ *  - query_GetTimestamp() - get the timestamp of the current value of the resource (any data type)
+ *  - query_GetBoolean() - get the current value of the resource, if the data type is Boolean
+ *  - query_GetNumeric() - get the current value of the resource, if the data type is numeric
+ *  - query_GetString() - get the current value of the resource, if the data type is string
+ *  - query_GetJson() - get the current value of the resource in JSON format (with any data type)
+ *
+ * All Observations that have non-zero buffer sizes with any type of data in them can have
+ * batches of samples fetched from their buffers in JSON format using
+ *  - query_ReadBufferJson().
+ *
+ * Alternatively, single samples can be fetched from a buffer using one of the following:
+ *  - query_ReadBufferSampleTimestamp()
+ *  - query_ReadBufferSampleBoolean()
+ *  - query_ReadBufferSampleNumeric()
+ *  - query_ReadBufferSampleString()
+ *  - query_ReadBufferSampleJson()
+ *
+ * If a JSON-type Input resource has provided an example of what its data samples might look like,
+ * it can be fetched using query_GetJsonExample().
+ *
+ *
+ * @section c_dataHubQuery_Statistics Data Set Statistics
+ *
+ * If an Observation is configured with a non-zero buffer size, it will collect a set of data
+ * in its buffer over time. Such Observations that are collecting numerical data sets support
+ * statistical queries on their data sets using the following functions:
+ *  - query_GetMin()
+ *  - query_GetMax()
+ *  - query_GetMean()
+ *  - query_GetStdDev()
+ *
+ * All of these functions return a numerical (floating-point) value.
+ *
+ *
+ * @section c_dataHubQuery_Watching Watching Resources
+ *
+ * Clients of the Admin API can register to receive call-backs whenever the current value
+ * of a any given resource gets updated.  The following functions are used to register
+ * update notification handlers for different types of data:
+ * - query_AddTriggerPushHandler() - notify of update, regardless of data type, but w/o a value.
+ * - query_AddBooleanPushHandler() - notify whenever current value is updated to a Boolean value.
+ * - query_AddNumericPushHandler() - notify whenever current value is updated to a numeric value.
+ * - query_AddStringPushHandler() - notify whenever current value is updated to a string value.
+ * - query_AddJsonPushHandler() - notify of update, regardless of data type, converted to JSON.
+ *
+ * Of course, these handlers can also be removed:
+ * - query_RemoveTriggerPushHandler()
+ * - query_RemoveBooleanPushHandler()
+ * - query_RemoveNumericPushHandler()
+ * - query_RemoveStringPushHandler()
+ * - query_RemoveJsonPushHandler()
+ *
+ *
+ * @section c_dataHubQuery_Snapshots Resource Tree Snapshots
+ *
+ * The snapshot API provides a mechanism to get the state of the resource tree at a given point in
+ * time.  The entire resource tree may be requested, or only a particular branch, and all values may
+ * be requested or only those that have changed since a certain point in time.  The API consists of
+ * two functions:
+ * - query_TakeSnapshot()
+ * - query_TrackDeletions()
+ *
+ * Copyright (C) Sierra Wireless Inc.
+ *
+ * @file query_interface.h
+ */
+
+#ifndef QUERY_INTERFACE_H_INCLUDE_GUARD
+#define QUERY_INTERFACE_H_INCLUDE_GUARD
+
+
+#include "legato.h"
+
+// Interface specific includes
+#include "io_interface.h"
+
+// Internal includes for this interface
+#include "query_common.h"
+//--------------------------------------------------------------------------------------------------
+/**
+ * Type for handler called when a server disconnects.
+ */
+//--------------------------------------------------------------------------------------------------
+typedef void (*query_DisconnectHandler_t)(void *);
+
+//--------------------------------------------------------------------------------------------------
+/**
+ *
+ * Connect the current client thread to the service providing this API. Block until the service is
+ * available.
+ *
+ * For each thread that wants to use this API, either ConnectService or TryConnectService must be
+ * called before any other functions in this API.  Normally, ConnectService is automatically called
+ * for the main thread, but not for any other thread. For details, see @ref apiFilesC_client.
+ *
+ * This function is created automatically.
+ */
+//--------------------------------------------------------------------------------------------------
+void query_ConnectService
+(
+    void
+);
+
+//--------------------------------------------------------------------------------------------------
+/**
+ *
+ * Try to connect the current client thread to the service providing this API. Return with an error
+ * if the service is not available.
+ *
+ * For each thread that wants to use this API, either ConnectService or TryConnectService must be
+ * called before any other functions in this API.  Normally, ConnectService is automatically called
+ * for the main thread, but not for any other thread. For details, see @ref apiFilesC_client.
+ *
+ * This function is created automatically.
+ *
+ * @return
+ *  - LE_OK if the client connected successfully to the service.
+ *  - LE_UNAVAILABLE if the server is not currently offering the service to which the client is
+ *    bound.
+ *  - LE_NOT_PERMITTED if the client interface is not bound to any service (doesn't have a binding).
+ *  - LE_COMM_ERROR if the Service Directory cannot be reached.
+ */
+//--------------------------------------------------------------------------------------------------
+le_result_t query_TryConnectService
+(
+    void
+);
+
+//--------------------------------------------------------------------------------------------------
+/**
+ * Set handler called when server disconnection is detected.
+ *
+ * When a server connection is lost, call this handler then exit with LE_FATAL.  If a program wants
+ * to continue without exiting, it should call longjmp() from inside the handler.
+ */
+//--------------------------------------------------------------------------------------------------
+LE_FULL_API void query_SetServerDisconnectHandler
+(
+    query_DisconnectHandler_t disconnectHandler,
+    void *contextPtr
+);
+
+//--------------------------------------------------------------------------------------------------
+/**
+ *
+ * Disconnect the current client thread from the service providing this API.
+ *
+ * Normally, this function doesn't need to be called. After this function is called, there's no
+ * longer a connection to the service, and the functions in this API can't be used. For details, see
+ * @ref apiFilesC_client.
+ *
+ * This function is created automatically.
+ */
+//--------------------------------------------------------------------------------------------------
+void query_DisconnectService
+(
+    void
+);
+
+
+//--------------------------------------------------------------------------------------------------
+/**
+ * Completion callbacks for query_ReadBufferJson() must look like this.
+ */
+//--------------------------------------------------------------------------------------------------
+
+
+//--------------------------------------------------------------------------------------------------
+/**
+ * Callback function for pushing triggers to an output
+ */
+//--------------------------------------------------------------------------------------------------
+
+
+//--------------------------------------------------------------------------------------------------
+/**
+ * Reference type used by Add/Remove functions for EVENT 'query_TriggerPush'
+ */
+//--------------------------------------------------------------------------------------------------
+
+
+//--------------------------------------------------------------------------------------------------
+/**
+ * Callback function for pushing Boolean values to an output
+ */
+//--------------------------------------------------------------------------------------------------
+
+
+//--------------------------------------------------------------------------------------------------
+/**
+ * Reference type used by Add/Remove functions for EVENT 'query_BooleanPush'
+ */
+//--------------------------------------------------------------------------------------------------
+
+
+//--------------------------------------------------------------------------------------------------
+/**
+ * Callback function for pushing numeric values to an output
+ */
+//--------------------------------------------------------------------------------------------------
+
+
+//--------------------------------------------------------------------------------------------------
+/**
+ * Reference type used by Add/Remove functions for EVENT 'query_NumericPush'
+ */
+//--------------------------------------------------------------------------------------------------
+
+
+//--------------------------------------------------------------------------------------------------
+/**
+ * Callback function for pushing string values to an output
+ */
+//--------------------------------------------------------------------------------------------------
+
+
+//--------------------------------------------------------------------------------------------------
+/**
+ * Reference type used by Add/Remove functions for EVENT 'query_StringPush'
+ */
+//--------------------------------------------------------------------------------------------------
+
+
+//--------------------------------------------------------------------------------------------------
+/**
+ * Callback function for pushing JSON values to an output
+ */
+//--------------------------------------------------------------------------------------------------
+
+
+//--------------------------------------------------------------------------------------------------
+/**
+ * Reference type used by Add/Remove functions for EVENT 'query_JsonPush'
+ */
+//--------------------------------------------------------------------------------------------------
+
+
+//--------------------------------------------------------------------------------------------------
+/**
+ */
+//--------------------------------------------------------------------------------------------------
+
+
+//--------------------------------------------------------------------------------------------------
+/**
+ */
+//--------------------------------------------------------------------------------------------------
+
+
+//--------------------------------------------------------------------------------------------------
+/**
+ */
+//--------------------------------------------------------------------------------------------------
+
+
+//--------------------------------------------------------------------------------------------------
+/**
+ * Read data out of a buffer.  Data is written to a given file descriptor in JSON-encoded format
+ * as an array of objects containing a timestamp and a value (or just a timestamp for triggers).
+ * E.g.,
+ *
+ * @code
+ * [{"t":1537483647.125,"v":true},{"t":1537483657.128,"v":true}]
+ * @endcode
+ *
+ * @return
+ *  - LE_OK if the read operation started successfully.
+ *  - LE_NOT_FOUND if the Observation doesn't exist.
+ */
+//--------------------------------------------------------------------------------------------------
+le_result_t query_ReadBufferJson
+(
+    const char* LE_NONNULL obsPath,
+        ///< [IN] Observation path. Can be absolute
+        ///< (beginning with a '/') or relative to /obs/.
+    double startAfter,
+        ///< [IN] Start after this many seconds ago,
+        ///< or after an absolute number of seconds since the Epoch
+        ///< (if startafter > 30 years).
+        ///< Use NAN (not a number) to read the whole buffer.
+    int outputFile,
+        ///< [IN] File descriptor to write the data to.
+    query_ReadCompletionFunc_t completionFuncPtr,
+        ///< [IN] Completion callback to be called when operation finishes.
+    void* contextPtr
+        ///< [IN]
+);
+
+//--------------------------------------------------------------------------------------------------
+/**
+ * Read the timestamp of a single sample from a buffer.
+ *
+ * @note This can be used with any type of sample.
+ *
+ * @return
+ *  - LE_OK if successful.
+ *  - LE_NOT_FOUND if the Observation doesn't exist or does not have a sample newer than the given
+ *                 startAfter timestamp.
+ */
+//--------------------------------------------------------------------------------------------------
+le_result_t query_ReadBufferSampleTimestamp
+(
+    const char* LE_NONNULL obsPath,
+        ///< [IN] Observation path. Can be absolute
+        ///< (beginning with a '/') or relative to /obs/.
+    double startAfter,
+        ///< [IN] Start after this many seconds ago,
+        ///< or after an absolute number of seconds since the Epoch
+        ///< (if startafter > 30 years).
+        ///< Use NAN (not a number) to read the oldest sample in the buffer.
+    double* timestampPtr
+        ///< [OUT] Timestamp of the sample, if LE_OK returned.
+);
+
+//--------------------------------------------------------------------------------------------------
+/**
+ * Read a single Boolean sample from a buffer.
+ *
+ * @warning This can only be used with Boolean type samples.
+ *
+ * @return
+ *  - LE_OK if successful.
+ *  - LE_NOT_FOUND if the Observation doesn't exist or does not have a Boolean sample newer than
+ *                 the given startAfter timestamp.
+ */
+//--------------------------------------------------------------------------------------------------
+le_result_t query_ReadBufferSampleBoolean
+(
+    const char* LE_NONNULL obsPath,
+        ///< [IN] Observation path. Can be absolute
+        ///< (beginning with a '/') or relative to /obs/.
+    double startAfter,
+        ///< [IN] Start after this many seconds ago,
+        ///< or after an absolute number of seconds since the Epoch
+        ///< (if startafter > 30 years).
+        ///< Use NAN (not a number) to read the oldest sample in the buffer.
+    double* timestampPtr,
+        ///< [OUT] Timestamp of the sample, if LE_OK returned.
+    bool* valuePtr
+        ///< [OUT] Value of the sample, if LE_OK returned.
+);
+
+//--------------------------------------------------------------------------------------------------
+/**
+ * Read a single numeric sample from a buffer.
+ *
+ * @warning This can only be used with numeric type samples.
+ *
+ * @return
+ *  - LE_OK if successful.
+ *  - LE_NOT_FOUND if the Observation doesn't exist or does not have a Numeric sample newer than
+ *                 the given startAfter timestamp.
+ */
+//--------------------------------------------------------------------------------------------------
+le_result_t query_ReadBufferSampleNumeric
+(
+    const char* LE_NONNULL obsPath,
+        ///< [IN] Observation path. Can be absolute
+        ///< (beginning with a '/') or relative to /obs/.
+    double startAfter,
+        ///< [IN] Start after this many seconds ago,
+        ///< or after an absolute number of seconds since the Epoch
+        ///< (if startafter > 30 years).
+        ///< Use NAN (not a number) to read the oldest sample in the buffer.
+    double* timestampPtr,
+        ///< [OUT] Timestamp of the sample, if LE_OK returned.
+    double* valuePtr
+        ///< [OUT] Value of the sample, if LE_OK returned.
+);
+
+//--------------------------------------------------------------------------------------------------
+/**
+ * Read a single sample from a buffer as a string.
+ *
+ * @note This can be used with any type of sample.
+ *
+ * @return
+ *  - LE_OK if successful.
+ *  - LE_NOT_FOUND if the Observation doesn't exist or does not have a sample newer than the given
+ *                 startAfter timestamp.
+ *  - LE_OVERFLOW if the buffer provided is too small to hold the value.
+ */
+//--------------------------------------------------------------------------------------------------
+le_result_t query_ReadBufferSampleString
+(
+    const char* LE_NONNULL obsPath,
+        ///< [IN] Observation path. Can be absolute
+        ///< (beginning with a '/') or relative to /obs/.
+    double startAfter,
+        ///< [IN] Start after this many seconds ago,
+        ///< or after an absolute number of seconds since the Epoch
+        ///< (if startafter > 30 years).
+        ///< Use NAN (not a number) to read the oldest sample in the buffer.
+    double* timestampPtr,
+        ///< [OUT] Timestamp of the sample, if LE_OK returned.
+    char* value,
+        ///< [OUT] Value of the sample, if LE_OK returned.
+    size_t valueSize
+        ///< [IN]
+);
+
+//--------------------------------------------------------------------------------------------------
+/**
+ * Read a single sample from a buffer as JSON.
+ *
+ * @note This can be used with any type of sample.
+ *
+ * @return
+ *  - LE_OK if successful.
+ *  - LE_NOT_FOUND if the Observation doesn't exist or does not have a sample newer than the given
+ *                 startAfter timestamp.
+ *  - LE_OVERFLOW if the buffer provided is too small to hold the value.
+ */
+//--------------------------------------------------------------------------------------------------
+le_result_t query_ReadBufferSampleJson
+(
+    const char* LE_NONNULL obsPath,
+        ///< [IN] Observation path. Can be absolute
+        ///< (beginning with a '/') or relative to /obs/.
+    double startAfter,
+        ///< [IN] Start after this many seconds ago,
+        ///< or after an absolute number of seconds since the Epoch
+        ///< (if startafter > 30 years).
+        ///< Use NAN (not a number) to read the oldest sample in the buffer.
+    double* timestampPtr,
+        ///< [OUT] Timestamp of the sample, if LE_OK returned.
+    char* value,
+        ///< [OUT] Value of the sample, if LE_OK returned.
+    size_t valueSize
+        ///< [IN]
+);
+
+//--------------------------------------------------------------------------------------------------
+/**
+ * Get the minimum value found in an Observation's data set within a given time span.
+ *
+ * @return The value, or NAN (not-a-number) if there's no numerical data in the Observation's
+ *         buffer (if the buffer size is zero, the buffer is empty, or the buffer contains data
+ *         of a non-numerical type).
+ */
+//--------------------------------------------------------------------------------------------------
+double query_GetMin
+(
+    const char* LE_NONNULL obsPath,
+        ///< [IN] Observation path. Can be absolute
+        ///< (beginning with a '/') or relative to /obs/.
+    double startTime
+        ///< [IN] If < 30 years then seconds before now; else seconds since the Epoch.
+);
+
+//--------------------------------------------------------------------------------------------------
+/**
+ * Get the maximum value found within a given time span in an Observation's buffer.
+ *
+ * @return The value, or NAN (not-a-number) if there's no numerical data in the Observation's
+ *         buffer (if the buffer size is zero, the buffer is empty, or the buffer contains data
+ *         of a non-numerical type).
+ */
+//--------------------------------------------------------------------------------------------------
+double query_GetMax
+(
+    const char* LE_NONNULL obsPath,
+        ///< [IN] Observation path. Can be absolute
+        ///< (beginning with a '/') or relative to /obs/.
+    double startTime
+        ///< [IN] If < 30 years then seconds before now; else seconds since the Epoch.
+);
+
+//--------------------------------------------------------------------------------------------------
+/**
+ * Get the mean (average) of all values found within a given time span in an Observation's buffer.
+ *
+ * @return The value, or NAN (not-a-number) if there's no numerical data in the Observation's
+ *         buffer (if the buffer size is zero, the buffer is empty, or the buffer contains data
+ *         of a non-numerical type).
+ */
+//--------------------------------------------------------------------------------------------------
+double query_GetMean
+(
+    const char* LE_NONNULL obsPath,
+        ///< [IN] Observation path. Can be absolute
+        ///< (beginning with a '/') or relative to /obs/.
+    double startTime
+        ///< [IN] If < 30 years then seconds before now; else seconds since the Epoch.
+);
+
+//--------------------------------------------------------------------------------------------------
+/**
+ * Get the standard deviation of all values found within a given time span in an
+ * Observation's buffer.
+ *
+ * @return The value, or NAN (not-a-number) if there's no numerical data in the Observation's
+ *         buffer (if the buffer size is zero, the buffer is empty, or the buffer contains data
+ *         of a non-numerical type).
+ */
+//--------------------------------------------------------------------------------------------------
+double query_GetStdDev
+(
+    const char* LE_NONNULL obsPath,
+        ///< [IN] Observation path. Can be absolute
+        ///< (beginning with a '/') or relative to /obs/.
+    double startTime
+        ///< [IN] If < 30 years then seconds before now; else seconds since the Epoch.
+);
+
+//--------------------------------------------------------------------------------------------------
+/**
+ * Get the current data type of a resource.
+ *
+ * @note Observations and Placeholders will default to IO_DATA_TYPE_TRIGGER, but will change
+ *       types as other types of data are pushed to them.  The data types of Inputs and Outputs
+ *       are decided by the apps that create them.
+ *
+ * @return
+ *  - LE_OK if successful.
+ *  - LE_NOT_FOUND if the resource was not found.
+ *  - LE_UNSUPPORTED if the path refers to a namespace (which can't have a data type).
+ */
+//--------------------------------------------------------------------------------------------------
+le_result_t query_GetDataType
+(
+    const char* LE_NONNULL path,
+        ///< [IN] Resource path. Can be absolute (beginning
+        ///< with a '/') or relative to the namespace of
+        ///< the calling app (/app/<app-name>/).
+    io_DataType_t* dataTypePtr
+        ///< [OUT] The fetched data type, if LE_OK is returned.
+);
+
+//--------------------------------------------------------------------------------------------------
+/**
+ * Get the current units of a resource.
+ *
+ * @note Observations and Placeholders will default to "", but will change units as data is
+ *       pushed to them.  The units of Inputs and Outputs are decided by the apps that create them.
+ *
+ * @return
+ *  - LE_OK if successful.
+ *  - LE_NOT_FOUND if the resource was not found.
+ *  - LE_UNSUPPORTED if the path refers to a namespace (which can't have a data type).
+ *  - LE_OVERFLOW if the units string was truncated because it is larger than the buffer provided.
+ */
+//--------------------------------------------------------------------------------------------------
+le_result_t query_GetUnits
+(
+    const char* LE_NONNULL path,
+        ///< [IN] Resource path. Can be absolute (beginning
+        ///< with a '/') or relative to the namespace of
+        ///< the calling app (/app/<app-name>/).
+    char* units,
+        ///< [OUT] The fetched units, if LE_OK is returned.
+    size_t unitsSize
+        ///< [IN]
+);
+
+//--------------------------------------------------------------------------------------------------
+/**
+ * Get the timestamp of the current value of a resource.
+ *
+ * @return
+ *  - LE_OK if successful.
+ *  - LE_NOT_FOUND if the resource was not found.
+ *  - LE_UNSUPPORTED if the path refers to a namespace (which can't have a data type).
+ *  - LE_UNAVAILABLE if the resource doesn't have a current value (yet).
+ */
+//--------------------------------------------------------------------------------------------------
+le_result_t query_GetTimestamp
+(
+    const char* LE_NONNULL path,
+        ///< [IN] Resource path. Can be absolute (beginning
+        ///< with a '/') or relative to the namespace of
+        ///< the calling app (/app/<app-name>/).
+    double* timestampPtr
+        ///< [OUT] The fetched timestamp (in seconds since the Epoch), if LE_OK returned.
+);
+
+//--------------------------------------------------------------------------------------------------
+/**
+ * Get the current value of a resource, if it's Boolean type.
+ *
+ * @return
+ *  - LE_OK if successful.
+ *  - LE_NOT_FOUND if the resource was not found.
+ *  - LE_UNSUPPORTED if the path refers to a namespace (which can't have a data type).
+ *  - LE_UNAVAILABLE if the resource doesn't have a current value (yet).
+ *  - LE_FORMAT_ERROR if the resource has another data type.
+ */
+//--------------------------------------------------------------------------------------------------
+le_result_t query_GetBoolean
+(
+    const char* LE_NONNULL path,
+        ///< [IN] Resource path. Can be absolute (beginning
+        ///< with a '/') or relative to the namespace of
+        ///< the calling app (/app/<app-name>/).
+    double* timestampPtr,
+        ///< [OUT] Fetched timestamp (in seconds since the Epoch), if LE_OK returned.
+    bool* valuePtr
+        ///< [OUT] Fetched value, if LE_OK returned.
+);
+
+//--------------------------------------------------------------------------------------------------
+/**
+ * Get the current value of a resource, if it's numeric type.
+ *
+ * @return
+ *  - LE_OK if successful.
+ *  - LE_NOT_FOUND if the resource was not found.
+ *  - LE_UNSUPPORTED if the path refers to a namespace (which can't have a data type).
+ *  - LE_UNAVAILABLE if the resource doesn't have a current value (yet).
+ *  - LE_FORMAT_ERROR if the resource has another data type.
+ */
+//--------------------------------------------------------------------------------------------------
+le_result_t query_GetNumeric
+(
+    const char* LE_NONNULL path,
+        ///< [IN] Resource path. Can be absolute (beginning
+        ///< with a '/') or relative to the namespace of
+        ///< the calling app (/app/<app-name>/).
+    double* timestampPtr,
+        ///< [OUT] Fetched timestamp (in seconds since the Epoch), if LE_OK returned.
+    double* valuePtr
+        ///< [OUT] Fetched value, if LE_OK returned.
+);
+
+//--------------------------------------------------------------------------------------------------
+/**
+ * Get the current value of a resource, if it's a string type.
+ *
+ * @return
+ *  - LE_OK if successful.
+ *  - LE_NOT_FOUND if the resource was not found.
+ *  - LE_UNSUPPORTED if the path refers to a namespace (which can't have a data type).
+ *  - LE_UNAVAILABLE if the resource doesn't have a current value (yet).
+ *  - LE_FORMAT_ERROR if the resource has another data type.
+ *  - LE_OVERFLOW if the value was truncated because it is larger than the buffer provided.
+ */
+//--------------------------------------------------------------------------------------------------
+le_result_t query_GetString
+(
+    const char* LE_NONNULL path,
+        ///< [IN] Resource path. Can be absolute (beginning
+        ///< with a '/') or relative to the namespace of
+        ///< the calling app (/app/<app-name>/).
+    double* timestampPtr,
+        ///< [OUT] Fetched timestamp (in seconds since the Epoch), if LE_OK returned.
+    char* value,
+        ///< [OUT] Fetched value, if LE_OK returned.
+    size_t valueSize
+        ///< [IN]
+);
+
+//--------------------------------------------------------------------------------------------------
+/**
+ * Get the current value of a resource of any type, in JSON format.
+ *
+ * @return
+ *  - LE_OK if successful.
+ *  - LE_NOT_FOUND if the resource was not found.
+ *  - LE_UNSUPPORTED if the path refers to a namespace (which can't have a data type).
+ *  - LE_UNAVAILABLE if the resource doesn't have a current value (yet).
+ *  - LE_OVERFLOW if the value was truncated because it is larger than the buffer provided.
+ */
+//--------------------------------------------------------------------------------------------------
+le_result_t query_GetJson
+(
+    const char* LE_NONNULL path,
+        ///< [IN] Resource path. Can be absolute (beginning
+        ///< with a '/') or relative to the namespace of
+        ///< the calling app (/app/<app-name>/).
+    double* timestampPtr,
+        ///< [OUT] Fetched timestamp (in seconds since the Epoch), if LE_OK returned.
+    char* value,
+        ///< [OUT] Fetched value, if LE_OK returned.
+    size_t valueSize
+        ///< [IN]
+);
+
+//--------------------------------------------------------------------------------------------------
+/**
+ * Fetch the example JSON value string for a given Input resource.
+ *
+ * @return
+ *  - LE_OK if successful.
+ *  - LE_NOT_FOUND if the resource was not found.
+ *  - LE_UNSUPPORTED if the path refers to something that doesn't have a JSON type.
+ *  - LE_UNAVAILABLE if the JSON-type resource doesn't have an example value.
+ *  - LE_OVERFLOW if the value was truncated because it is larger than the buffer provided.
+ */
+//--------------------------------------------------------------------------------------------------
+le_result_t query_GetJsonExample
+(
+    const char* LE_NONNULL path,
+        ///< [IN] Resource path. Can be absolute (beginning
+        ///< with a '/') or relative to the namespace of
+        ///< the calling app (/app/<app-name>/).
+    char* example,
+        ///< [OUT] Example will be put here, if LE_OK returned.
+    size_t exampleSize
+        ///< [IN]
+);
+
+//--------------------------------------------------------------------------------------------------
+/**
+ * Add handler function for EVENT 'query_TriggerPush'
+ */
+//--------------------------------------------------------------------------------------------------
+query_TriggerPushHandlerRef_t query_AddTriggerPushHandler
+(
+    const char* LE_NONNULL path,
+        ///< [IN] Absolute path of resource.
+    query_TriggerPushHandlerFunc_t callbackPtr,
+        ///< [IN]
+    void* contextPtr
+        ///< [IN]
+);
+
+//--------------------------------------------------------------------------------------------------
+/**
+ * Remove handler function for EVENT 'query_TriggerPush'
+ */
+//--------------------------------------------------------------------------------------------------
+void query_RemoveTriggerPushHandler
+(
+    query_TriggerPushHandlerRef_t handlerRef
+        ///< [IN]
+);
+
+//--------------------------------------------------------------------------------------------------
+/**
+ * Add handler function for EVENT 'query_BooleanPush'
+ */
+//--------------------------------------------------------------------------------------------------
+query_BooleanPushHandlerRef_t query_AddBooleanPushHandler
+(
+    const char* LE_NONNULL path,
+        ///< [IN] Absolute path of resource.
+    query_BooleanPushHandlerFunc_t callbackPtr,
+        ///< [IN]
+    void* contextPtr
+        ///< [IN]
+);
+
+//--------------------------------------------------------------------------------------------------
+/**
+ * Remove handler function for EVENT 'query_BooleanPush'
+ */
+//--------------------------------------------------------------------------------------------------
+void query_RemoveBooleanPushHandler
+(
+    query_BooleanPushHandlerRef_t handlerRef
+        ///< [IN]
+);
+
+//--------------------------------------------------------------------------------------------------
+/**
+ * Add handler function for EVENT 'query_NumericPush'
+ */
+//--------------------------------------------------------------------------------------------------
+query_NumericPushHandlerRef_t query_AddNumericPushHandler
+(
+    const char* LE_NONNULL path,
+        ///< [IN] Absolute path of resource.
+    query_NumericPushHandlerFunc_t callbackPtr,
+        ///< [IN]
+    void* contextPtr
+        ///< [IN]
+);
+
+//--------------------------------------------------------------------------------------------------
+/**
+ * Remove handler function for EVENT 'query_NumericPush'
+ */
+//--------------------------------------------------------------------------------------------------
+void query_RemoveNumericPushHandler
+(
+    query_NumericPushHandlerRef_t handlerRef
+        ///< [IN]
+);
+
+//--------------------------------------------------------------------------------------------------
+/**
+ * Add handler function for EVENT 'query_StringPush'
+ */
+//--------------------------------------------------------------------------------------------------
+query_StringPushHandlerRef_t query_AddStringPushHandler
+(
+    const char* LE_NONNULL path,
+        ///< [IN] Absolute path of resource.
+    query_StringPushHandlerFunc_t callbackPtr,
+        ///< [IN]
+    void* contextPtr
+        ///< [IN]
+);
+
+//--------------------------------------------------------------------------------------------------
+/**
+ * Remove handler function for EVENT 'query_StringPush'
+ */
+//--------------------------------------------------------------------------------------------------
+void query_RemoveStringPushHandler
+(
+    query_StringPushHandlerRef_t handlerRef
+        ///< [IN]
+);
+
+//--------------------------------------------------------------------------------------------------
+/**
+ * Add handler function for EVENT 'query_JsonPush'
+ */
+//--------------------------------------------------------------------------------------------------
+query_JsonPushHandlerRef_t query_AddJsonPushHandler
+(
+    const char* LE_NONNULL path,
+        ///< [IN] Absolute path of resource.
+    query_JsonPushHandlerFunc_t callbackPtr,
+        ///< [IN]
+    void* contextPtr
+        ///< [IN]
+);
+
+//--------------------------------------------------------------------------------------------------
+/**
+ * Remove handler function for EVENT 'query_JsonPush'
+ */
+//--------------------------------------------------------------------------------------------------
+void query_RemoveJsonPushHandler
+(
+    query_JsonPushHandlerRef_t handlerRef
+        ///< [IN]
+);
+
+//--------------------------------------------------------------------------------------------------
+/**
+ */
+//--------------------------------------------------------------------------------------------------
+void query_TakeSnapshot
+(
+    uint32_t format,
+        ///< [IN] Snapshot output data format.
+    query_SnapshotFlag_t flags,
+        ///< [IN] Flags controlling the
+        ///< snapshot action.
+    const char* LE_NONNULL path,
+        ///< [IN] Tree path to use as the root.
+    double since,
+        ///< [IN] Request only values that have
+        ///< changed since this time (in s).
+        ///< Use BEGINNING_OF_TIME to
+        ///< request the full tree.
+    query_HandleSnapshotResultFunc_t callbackPtr,
+        ///< [IN] Completion callback to indicate
+        ///< the end of the streamed
+        ///< snapshot, or an error.
+    void* contextPtr,
+        ///< [IN]
+    int* snapshotStreamPtr
+        ///< [OUT] File descriptor to which the
+        ///< encoded snapshot data will be
+        ///< streamed.
+);
+
+//--------------------------------------------------------------------------------------------------
+/**
+ */
+//--------------------------------------------------------------------------------------------------
+void query_TrackDeletions
+(
+    bool on
+        ///< [IN] If true, start tracking deletions; if false stop tracking and flush records.
+);
+
+#endif // QUERY_INTERFACE_H_INCLUDE_GUARD


### PR DESCRIPTION
To allow Octave applications re-architecture without breaking change of the resource tree, we need to be able to create and delete resources in a given namespace.

API functions created

`admin_CreateInput`
`admin_CreateOutput`
`admin_DeleteResource`

Those API functions are also required

`admin_SetJsonExample`
`admin_MarkOptional`

Checklist:
- [x] unit tests added
- [x] formatted following: [edge conventions](https://confluence.sierrawireless.com/display/BROOKLYN/Octave+Edge+Software+Development)
- [x] :bomb: No compatibility break: API or resource format compatible with older blueprints
- [x] :dart: Focuses only on necessary changes

I created Unit tests in Data Hub repo:

```
[fx30]admin(18_admin_create_delete_resources) make tests 
cc -g -m32 -Wall -Werror -o build/test/admintest mock.c main.c ../../components/dataHub/ioService.c ../../components/dataHub/adminService.c ../../components/dataHub/dataHub.c ../../components/dataHub/resource.c ../../components/dataHub/dataSample.c ../../components/dataHub/ioPoint.c ../../components/dataHub/obs.c ../../components/dataHub/resTree.c ../../components/dataHub/handler.c ../../components/dataHub/queryService.c ../../components/dataHub/snapshot.c ../../components/json/json.c ../../components/jsonFormatter/jsonFormatter.c build/test/liblegato/*.o build/test/liblegato/linux/*.o -I. -I../../components/dataHub -I../../components/json -I../../components/jsonFormatter -I/work/repo/legato-r14-fx30/legato/framework/include -I/work/repo/legato-r14-fx30/legato/framework/liblegato/ -I/work/repo/legato-r14-fx30/legato/framework/daemons/linux/ -I/work/repo/legato-r14-fx30/legato/build/wp77xx/framework/include/ -I/work/repo/legato-r14-fx30/legato/build/wp77xx/3rdParty/inc -DUNIT_TEST -lpthread -ldl -lcmocka -lm
build/test/admintest
Apr  6 14:21:52 : -WRN- | _UNKNOWN_[124561]/ T= | timer.c fa_timer_Init() 173 | Using CLOCK_BOOTTIME: alarm wakeups not supported.
[==========] Running 8 test(s).
Apr  6 14:21:52 :  INFO | _UNKNOWN_[124561]/ T=main | dataHub.c initDataHub() 58 | Data Hub started.
[ RUN      ] test_admin_create_delete_input
[       OK ] test_admin_create_delete_input
[ RUN      ] test_admin_create_input_bad_path
Apr  6 14:21:52 : =ERR= | _UNKNOWN_[124561]/ T=main | resTree.c resTree_FindEntryAtAbsolutePath() 421 | Path not absolute.
Apr  6 14:21:52 : =ERR= | _UNKNOWN_[124561]/ T=main | adminService.c ExtractAppNameFromAbsolutePath() 2233 | Path 'app/toto/value' is not absolute.
Apr  6 14:21:52 : =ERR= | _UNKNOWN_[124561]/ T=main | adminService.c admin_CreateInput() 2334 | Failed to extract app name from abs path 'app/toto/value'.
Apr  6 14:21:52 : =ERR= | _UNKNOWN_[124561]/ T=main | adminService.c ExtractAppNameFromAbsolutePath() 2233 | Path '//app/toto/value' is not absolute.
Apr  6 14:21:52 : =ERR= | _UNKNOWN_[124561]/ T=main | adminService.c admin_CreateInput() 2334 | Failed to extract app name from abs path '//app/toto/value'.
Apr  6 14:21:52 : =ERR= | _UNKNOWN_[124561]/ T=main | adminService.c ExtractAppNameFromAbsolutePath() 2233 | Path '/toto/value' is not absolute.
Apr  6 14:21:52 : =ERR= | _UNKNOWN_[124561]/ T=main | adminService.c admin_CreateInput() 2334 | Failed to extract app name from abs path '/toto/value'.
Apr  6 14:21:52 : =ERR= | _UNKNOWN_[124561]/ T=main | resTree.c resTree_FindEntryAtAbsolutePath() 421 | Path not absolute.
Apr  6 14:21:52 : =ERR= | _UNKNOWN_[124561]/ T=main | adminService.c ExtractAppNameFromAbsolutePath() 2233 | Path 'toto/value' is not absolute.
Apr  6 14:21:52 : =ERR= | _UNKNOWN_[124561]/ T=main | adminService.c admin_CreateInput() 2334 | Failed to extract app name from abs path 'toto/value'.
[       OK ] test_admin_create_input_bad_path
[ RUN      ] test_admin_create_input_duplicate
[       OK ] test_admin_create_input_duplicate
[ RUN      ] test_admin_create_delete_output
[       OK ] test_admin_create_delete_output
[ RUN      ] test_admin_create_output_bad_path
Apr  6 14:21:52 : =ERR= | _UNKNOWN_[124561]/ T=main | resTree.c resTree_FindEntryAtAbsolutePath() 421 | Path not absolute.
Apr  6 14:21:52 : =ERR= | _UNKNOWN_[124561]/ T=main | adminService.c ExtractAppNameFromAbsolutePath() 2233 | Path 'app/toto/value' is not absolute.
Apr  6 14:21:52 : =ERR= | _UNKNOWN_[124561]/ T=main | adminService.c admin_CreateOutput() 2421 | Failed to extract app name from abs path 'app/toto/value'.
Apr  6 14:21:52 : =ERR= | _UNKNOWN_[124561]/ T=main | adminService.c ExtractAppNameFromAbsolutePath() 2233 | Path '//app/toto/value' is not absolute.
Apr  6 14:21:52 : =ERR= | _UNKNOWN_[124561]/ T=main | adminService.c admin_CreateOutput() 2421 | Failed to extract app name from abs path '//app/toto/value'.
Apr  6 14:21:52 : =ERR= | _UNKNOWN_[124561]/ T=main | adminService.c ExtractAppNameFromAbsolutePath() 2233 | Path '/toto/value' is not absolute.
Apr  6 14:21:52 : =ERR= | _UNKNOWN_[124561]/ T=main | adminService.c admin_CreateOutput() 2421 | Failed to extract app name from abs path '/toto/value'.
Apr  6 14:21:52 : =ERR= | _UNKNOWN_[124561]/ T=main | resTree.c resTree_FindEntryAtAbsolutePath() 421 | Path not absolute.
Apr  6 14:21:52 : =ERR= | _UNKNOWN_[124561]/ T=main | adminService.c ExtractAppNameFromAbsolutePath() 2233 | Path 'toto/value' is not absolute.
Apr  6 14:21:52 : =ERR= | _UNKNOWN_[124561]/ T=main | adminService.c admin_CreateOutput() 2421 | Failed to extract app name from abs path 'toto/value'.
[       OK ] test_admin_create_output_bad_path
[ RUN      ] test_admin_create_output_duplicate
[       OK ] test_admin_create_output_duplicate
[ RUN      ] test_admin_mark_optional
[       OK ] test_admin_mark_optional
[ RUN      ] test_admin_set_json_example
Apr  6 14:21:52 : -WRN- | _UNKNOWN_[124561]/ T=main | resource.c res_Destruct() 310 | Resource had a JSON example value.
Apr  6 14:21:52 : -WRN- | _UNKNOWN_[124561]/ T=main | resource.c res_Destruct() 310 | Resource had a JSON example value.
Apr  6 14:21:52 : -WRN- | _UNKNOWN_[124561]/ T=main | resource.c res_Destruct() 310 | Resource had a JSON example value.
Apr  6 14:21:52 : -WRN- | _UNKNOWN_[124561]/ T=main | resource.c res_Destruct() 310 | Resource had a JSON example value.
Apr  6 14:21:52 : -WRN- | _UNKNOWN_[124561]/ T=main | resource.c res_Destruct() 310 | Resource had a JSON example value.
[       OK ] test_admin_set_json_example
[==========] 8 test(s) run.
[  PASSED  ] 8 test(s).

```

I also did some tests on target:

```
static void testTriggerHandler(double timestamp, void *contextPtr)
{
    LE_UNUSED(contextPtr);

    admin_PushNumeric("/app/year/may/value", IO_NOW, timestamp);
    admin_PushNumeric("/app/year/june/value", IO_NOW, timestamp);
}

COMPONENT_INIT
{
    // TEST
    admin_CreateInput("/app/toto/value", IO_DATA_TYPE_JSON, "");
    admin_CreateInput("/app/titi/tutu/value", IO_DATA_TYPE_JSON, "");
    admin_CreateInput("/app/tata/tutu/value", IO_DATA_TYPE_JSON, "");

    admin_CreateInput("/app/year/january/value", IO_DATA_TYPE_TRIGGER, "");

    admin_CreateInput("/app/year/february/value", IO_DATA_TYPE_NUMERIC, "");
    admin_CreateInput("/app/year/march/value", IO_DATA_TYPE_JSON, "");

    admin_CreateOutput("/app/year/april/value", IO_DATA_TYPE_TRIGGER, "");
    admin_AddTriggerPushHandler("/app/year/april/value", testTriggerHandler, NULL);

    admin_CreateOutput("/app/year/may/value", IO_DATA_TYPE_NUMERIC, "");
    admin_MarkOptional("/app/year/may/value");

    admin_CreateOutput("/app/year/june/value", IO_DATA_TYPE_JSON, "");
    admin_MarkOptional("/app/year/june/value");
}
```